### PR TITLE
console handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ vendor/bin/psalm-plugin enable psalm/plugin-symfony
 ### Features
 
 - Detect `ContainerInterface::get()` result type. Works better if you [configure](#configuration) compiled container XML file.
+- Detect return type of console arguments (`InputInterface::getArgument()`) and options (`InputInterface::getOption()`). Enforces
+to use InputArgument and InputOption constants as a part of best practise.
 - Fixes `PossiblyInvalidArgument` for `Symfony\Component\HttpFoundation\Request::getContent`.
 The plugin calculates real return type by checking the given argument and marks return type as either string or resource.
 - Complains when `Container` is injected to a service. Use dependency-injection.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require-dev": {
         "codeception/base": "^2.5",
         "weirdan/codeception-psalm-module": "^0.2.2",
-        "phpunit/phpunit": "~7.5"
+        "phpunit/phpunit": "~7.5",
+        "symfony/console": "*"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,5 +10,10 @@
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>
+
     </projectFiles>
+
+    <plugins>
+        <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+    </plugins>
 </psalm>

--- a/src/Exception/InvalidConsoleModeException.php
+++ b/src/Exception/InvalidConsoleModeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Psalm\SymfonyPsalmPlugin\Exception;
+
+class InvalidConsoleModeException extends \InvalidArgumentException
+{
+}

--- a/src/Handler/ClassHandler.php
+++ b/src/Handler/ClassHandler.php
@@ -13,9 +13,9 @@ use Psalm\Plugin\Hook\AfterClassLikeAnalysisInterface;
 use Psalm\Plugin\Hook\AfterMethodCallAnalysisInterface;
 use Psalm\StatementsSource;
 use Psalm\Storage\ClassLikeStorage;
-use Psalm\Type\Union;
 use Psalm\SymfonyPsalmPlugin\Issue\ContainerDependency;
 use Psalm\SymfonyPsalmPlugin\Issue\RepositoryStringShortcut;
+use Psalm\Type\Union;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ClassHandler implements AfterClassLikeAnalysisInterface, AfterMethodCallAnalysisInterface

--- a/src/Handler/ConsoleHandler.php
+++ b/src/Handler/ConsoleHandler.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Psalm\SymfonyPsalmPlugin\Handler;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\IssueBuffer;
+use Psalm\Plugin\Hook\AfterMethodCallAnalysisInterface;
+use Psalm\StatementsSource;
+use Psalm\SymfonyPsalmPlugin\Exception\InvalidConsoleModeException;
+use Psalm\SymfonyPsalmPlugin\Issue\InvalidConsoleArgumentValue;
+use Psalm\SymfonyPsalmPlugin\Issue\InvalidConsoleOptionValue;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TBool;
+use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Union;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class ConsoleHandler implements AfterMethodCallAnalysisInterface
+{
+    /**
+     * @var Union[]
+     */
+    private static $arguments = [];
+    /**
+     * @var Union[]
+     */
+    private static $options = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function afterMethodCallAnalysis(
+        Expr $expr,
+        string $method_id,
+        string $appearing_method_id,
+        string $declaring_method_id,
+        Context $context,
+        StatementsSource $statements_source,
+        Codebase $codebase,
+        array &$file_replacements = [],
+        Union &$return_type_candidate = null
+    ) {
+        switch ($declaring_method_id) {
+            case 'Symfony\Component\Console\Command\Command::addargument':
+                /** @psalm-suppress PossiblyInvalidArgument */
+                self::analyseArgument($expr, $statements_source);
+                break;
+            case 'Symfony\Component\Console\Input\InputInterface::getargument':
+                /** @var String_ $argumentName */
+                $argumentName = $expr->args[0]->value;
+                $argumentNameValue = $argumentName->value;
+                if (isset(self::$arguments[$argumentNameValue])) {
+                    $return_type_candidate = self::$arguments[$argumentNameValue];
+                }
+                break;
+            case 'Symfony\Component\Console\Command\Command::addoption':
+                /** @psalm-suppress PossiblyInvalidArgument */
+                self::analyseOption($expr, $statements_source);
+                break;
+            case 'Symfony\Component\Console\Input\InputInterface::getoption':
+                /** @var String_ $optionName */
+                $optionName = $expr->args[0]->value;
+                $optionNameValue = $optionName->value;
+                if (isset(self::$options[$optionNameValue])) {
+                    $return_type_candidate = self::$options[$optionNameValue];
+                }
+                break;
+        }
+    }
+
+    private static function analyseArgument(Expr\MethodCall $expr, StatementsSource $statements_source): void
+    {
+        if (count($expr->args) > 1) {
+            try {
+                $mode = self::getModeValue($expr->args[1]->value, InputArgument::class);
+            } catch (InvalidConsoleModeException $e) {
+                IssueBuffer::accepts(
+                    new InvalidConsoleArgumentValue(new CodeLocation($statements_source, $expr->args[1]->value)),
+                    $statements_source->getSuppressedIssues()
+                );
+                return;
+            }
+        } else {
+            $mode = InputArgument::OPTIONAL;
+        }
+
+        $returnTypes = new Union([new TString(), new TNull()]);
+
+        if ($mode & InputArgument::REQUIRED) {
+            $returnTypes->removeType('null');
+        }
+
+        if ($mode & InputArgument::IS_ARRAY) {
+            $returnTypes->removeType('string');
+            $returnTypes->addType(new TArray([new Union([new TInt()]), new Union([new TString()])]));
+        }
+
+        /** @var String_ $argumentName */
+        $argumentName = $expr->args[0]->value;
+
+        self::$arguments[$argumentName->value] = $returnTypes;
+    }
+
+    private static function analyseOption(Expr\MethodCall $expr, StatementsSource $statements_source): void
+    {
+        if (isset($expr->args[2])) {
+            try {
+                $mode = self::getModeValue($expr->args[2]->value, InputOption::class);
+            } catch (InvalidConsoleModeException $e) {
+                IssueBuffer::accepts(
+                    new InvalidConsoleOptionValue(new CodeLocation($statements_source, $expr->args[2]->value)),
+                    $statements_source->getSuppressedIssues()
+                );
+                return;
+            }
+        } else {
+            $mode = InputOption::VALUE_OPTIONAL;
+        }
+
+        $returnTypes = new Union([new TString(), new TNull()]);
+
+        if ($mode & InputOption::VALUE_NONE) {
+            $returnTypes = new Union([new TBool()]);
+        }
+
+        if ($mode & InputOption::VALUE_REQUIRED) {
+            $returnTypes->removeType('null');
+        }
+
+        if ($mode & InputOption::VALUE_IS_ARRAY) {
+            $returnTypes->removeType('string');
+            $returnTypes->addType(new TArray([new Union([new TInt()]), new Union([new TString()])]));
+        }
+
+        /** @var String_ $optionName */
+        $optionName = $expr->args[0]->value;
+
+        self::$options[$optionName->value] = $returnTypes;
+    }
+
+    /**
+     * @param mixed $mode
+     */
+    private static function getModeValue($mode, string $className): int
+    {
+        if ($mode instanceof Expr\BinaryOp\BitwiseOr) {
+            return self::getModeValue($mode->left, $className) | self::getModeValue($mode->right, $className);
+        }
+
+        if ($mode instanceof Expr\ClassConstFetch) {
+            /** @var Identifier $constName */
+            $constName = $mode->name;
+            /** @var int $value */
+            $value = constant($className.'::'.$constName->name);
+            return $value;
+        }
+
+        throw new InvalidConsoleModeException();
+    }
+}

--- a/src/Handler/ContainerXmlHandler.php
+++ b/src/Handler/ContainerXmlHandler.php
@@ -11,11 +11,11 @@ use Psalm\Context;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\Hook\AfterMethodCallAnalysisInterface;
 use Psalm\StatementsSource;
-use Psalm\Type\Atomic\TNamedObject;
-use Psalm\Type\Union;
 use Psalm\SymfonyPsalmPlugin\Issue\PrivateService;
 use Psalm\SymfonyPsalmPlugin\Issue\ServiceNotFound;
 use Psalm\SymfonyPsalmPlugin\Symfony\ContainerMeta;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
 
 class ContainerXmlHandler implements AfterMethodCallAnalysisInterface
 {

--- a/src/Issue/InvalidConsoleArgumentValue.php
+++ b/src/Issue/InvalidConsoleArgumentValue.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Psalm\SymfonyPsalmPlugin\Issue;
+
+use Psalm\CodeLocation;
+use Psalm\Issue\CodeIssue;
+
+class InvalidConsoleArgumentValue extends CodeIssue
+{
+    public function __construct(CodeLocation $code_location)
+    {
+        parent::__construct('Use Symfony\Component\Console\Input\InputArgument constants', $code_location);
+    }
+}

--- a/src/Issue/InvalidConsoleOptionValue.php
+++ b/src/Issue/InvalidConsoleOptionValue.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Psalm\SymfonyPsalmPlugin\Issue;
+
+use Psalm\CodeLocation;
+use Psalm\Issue\CodeIssue;
+
+class InvalidConsoleOptionValue extends CodeIssue
+{
+    public function __construct(CodeLocation $code_location)
+    {
+        parent::__construct('Use Symfony\Component\Console\Input\InputOption constants', $code_location);
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -6,6 +6,7 @@ use Psalm\Exception\ConfigException;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
 use Psalm\SymfonyPsalmPlugin\Handler\ClassHandler;
+use Psalm\SymfonyPsalmPlugin\Handler\ConsoleHandler;
 use Psalm\SymfonyPsalmPlugin\Handler\ContainerHandler;
 use Psalm\SymfonyPsalmPlugin\Handler\ContainerXmlHandler;
 use Psalm\SymfonyPsalmPlugin\Symfony\ContainerMeta;
@@ -21,8 +22,10 @@ class Plugin implements PluginEntryPointInterface
         require_once __DIR__.'/Handler/ClassHandler.php';
         require_once __DIR__.'/Handler/ContainerHandler.php';
         require_once __DIR__.'/Handler/ContainerXmlHandler.php';
+        require_once __DIR__.'/Handler/ConsoleHandler.php';
 
         $api->registerHooksFromClass(ClassHandler::class);
+        $api->registerHooksFromClass(ConsoleHandler::class);
 
         if (isset($config->containerXml)) {
             $containerXmlPath = realpath((string) $config->containerXml);

--- a/tests/acceptance/acceptance/ConsoleArgument.feature
+++ b/tests/acceptance/acceptance/ConsoleArgument.feature
@@ -1,0 +1,116 @@
+Feature: ConsoleArgument
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+
+  Scenario: Using argument mode other than defined constants raises issue
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Component\Console\Command\Command;
+      use Symfony\Component\Console\Input\InputArgument;
+
+      class MyCommand extends Command
+      {
+        public function configure(): void
+        {
+          $this->addArgument('required_string', 1, 'String required argument');
+        }
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type                        | Message                                                     |
+      | InvalidConsoleArgumentValue | Use Symfony\Component\Console\Input\InputArgument constants |
+    And I see no other errors
+
+  Scenario: Asserting arguments return types have inferred (without error)
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Component\Console\Command\Command;
+      use Symfony\Component\Console\Input\InputArgument;
+      use Symfony\Component\Console\Input\InputInterface;
+      use Symfony\Component\Console\Output\OutputInterface;
+
+      class MyCommand extends Command
+      {
+        public function configure(): void
+        {
+          $this->addArgument('required_string', InputArgument::REQUIRED);
+          $this->addArgument('required_array', InputArgument::REQUIRED | InputArgument::IS_ARRAY);
+        }
+
+        public function execute(InputInterface $input, OutputInterface $output): int
+        {
+          $string = $input->getArgument('required_string');
+          $output->writeLn(sprintf('%s', $string));
+
+          $array = $input->getArgument('required_array');
+          shuffle($array);
+
+          return 0;
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Asserting arguments return types have inferred (with errors)
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Component\Console\Command\Command;
+      use Symfony\Component\Console\Input\InputArgument;
+      use Symfony\Component\Console\Input\InputInterface;
+      use Symfony\Component\Console\Output\OutputInterface;
+
+      class MyCommand extends Command
+      {
+        public function configure(): void
+        {
+          $this->addArgument('optional_string1');
+          $this->addArgument('optional_string2', InputArgument::OPTIONAL);
+          $this->addArgument('optional_array1', InputArgument::OPTIONAL | InputArgument::IS_ARRAY);
+          $this->addArgument('optional_array2', InputArgument::IS_ARRAY);
+        }
+
+        public function execute(InputInterface $input, OutputInterface $output): int
+        {
+          $string1 = $input->getArgument('optional_string1');
+          $output->writeLn(sprintf('%s', $string1));
+          $string2 = $input->getArgument('optional_string2');
+          $output->writeLn(sprintf('%s', $string2));
+
+          $array1 = $input->getArgument('optional_array1');
+          shuffle($array1);
+          $array2 = $input->getArgument('optional_array2');
+          shuffle($array2);
+
+          return 0;
+        }
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type                 | Message                                                            |
+      | PossiblyNullArgument | Argument 2 of sprintf cannot be null, possibly null value provided |
+      | PossiblyNullArgument | Argument 2 of sprintf cannot be null, possibly null value provided |
+      | PossiblyNullArgument | Argument 1 of shuffle cannot be null, possibly null value provided |
+      | PossiblyNullArgument | Argument 1 of shuffle cannot be null, possibly null value provided |
+    And I see no other errors

--- a/tests/acceptance/acceptance/ConsoleOption.feature
+++ b/tests/acceptance/acceptance/ConsoleOption.feature
@@ -1,0 +1,113 @@
+Feature: ConsoleOption
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+
+  Scenario: Using option mode other than defined constants raises issue
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Component\Console\Command\Command;
+
+      class MyCommand extends Command
+      {
+        public function configure(): void
+        {
+          $this->addOption('option', null, 1);
+        }
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type                        | Message                                                     |
+      | InvalidConsoleOptionValue   | Use Symfony\Component\Console\Input\InputOption constants   |
+    And I see no other errors
+
+  Scenario: Asserting options return types have inferred (without error)
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Component\Console\Command\Command;
+      use Symfony\Component\Console\Input\InputOption;
+      use Symfony\Component\Console\Input\InputInterface;
+      use Symfony\Component\Console\Output\OutputInterface;
+
+      class MyCommand extends Command
+      {
+        public function configure(): void
+        {
+          $this->addOption('required_array', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+          $this->addOption('required_string', null, InputOption::VALUE_REQUIRED);
+          $this->addOption('boolean', null, InputOption::VALUE_NONE);
+        }
+
+        public function execute(InputInterface $input, OutputInterface $output): int
+        {
+          $string = $input->getOption('required_string');
+          $output->writeLn(sprintf('%s', $string));
+
+          $array = $input->getOption('required_array');
+          shuffle($array);
+
+          $this->boolean($input->getOption('boolean'));
+
+          return 0;
+        }
+
+        private function boolean(bool $input): void
+        {
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Asserting options return types have inferred (with errors)
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Component\Console\Command\Command;
+      use Symfony\Component\Console\Input\InputOption;
+      use Symfony\Component\Console\Input\InputInterface;
+      use Symfony\Component\Console\Output\OutputInterface;
+
+      class MyCommand extends Command
+      {
+        public function configure(): void
+        {
+          $this->addOption('optional_string1');
+          $this->addOption('optional_string2', null, InputOption::VALUE_OPTIONAL);
+        }
+
+        public function execute(InputInterface $input, OutputInterface $output): int
+        {
+          $string1 = $input->getOption('optional_string1');
+          $output->writeLn(sprintf('%s', $string1));
+          $string2 = $input->getOption('optional_string2');
+          $output->writeLn(sprintf('%s', $string2));
+
+          return 0;
+        }
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type                 | Message                                                            |
+      | PossiblyNullArgument | Argument 2 of sprintf cannot be null, possibly null value provided |
+      | PossiblyNullArgument | Argument 2 of sprintf cannot be null, possibly null value provided |
+    And I see no other errors


### PR DESCRIPTION
fixes #17

Detect return type of console arguments (`InputInterface::getArgument()`) and options (`InputInterface::getOption()`). Enforces
to use InputArgument and InputOption constants as a part of best practise.