### PR TITLE
[console] skip dynamic argument and option names

### DIFF
--- a/src/Handler/ConsoleHandler.php
+++ b/src/Handler/ConsoleHandler.php
@@ -53,8 +53,10 @@ class ConsoleHandler implements AfterMethodCallAnalysisInterface
                 self::analyseArgument($expr, $statements_source);
                 break;
             case 'Symfony\Component\Console\Input\InputInterface::getargument':
-                /** @var String_ $argumentName */
                 $argumentName = $expr->args[0]->value;
+                if (!$argumentName instanceof String_) {
+                    break;
+                }
                 $argumentNameValue = $argumentName->value;
                 if (isset(self::$arguments[$argumentNameValue])) {
                     $return_type_candidate = self::$arguments[$argumentNameValue];
@@ -65,8 +67,10 @@ class ConsoleHandler implements AfterMethodCallAnalysisInterface
                 self::analyseOption($expr, $statements_source);
                 break;
             case 'Symfony\Component\Console\Input\InputInterface::getoption':
-                /** @var String_ $optionName */
                 $optionName = $expr->args[0]->value;
+                if (!$optionName instanceof String_) {
+                    break;
+                }
                 $optionNameValue = $optionName->value;
                 if (isset(self::$options[$optionNameValue])) {
                     $return_type_candidate = self::$options[$optionNameValue];

--- a/tests/acceptance/acceptance/ConsoleOption.feature
+++ b/tests/acceptance/acceptance/ConsoleOption.feature
@@ -111,3 +111,36 @@ Feature: ConsoleOption
       | PossiblyNullArgument | Argument 2 of sprintf cannot be null, possibly null value provided |
       | PossiblyNullArgument | Argument 2 of sprintf cannot be null, possibly null value provided |
     And I see no other errors
+
+  Scenario: Cannot evaluate dynamic option names
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Component\Console\Command\Command;
+      use Symfony\Component\Console\Input\InputOption;
+      use Symfony\Component\Console\Input\InputInterface;
+      use Symfony\Component\Console\Output\OutputInterface;
+
+      class MyCommand extends Command
+      {
+        public function configure(): void
+        {
+          $this->addOption('foo');
+        }
+
+        public function execute(InputInterface $input, OutputInterface $output): int
+        {
+          $optionName = 'foo';
+          $string1 = $input->getOption($optionName);
+          $output->writeLn(sprintf('%s', $string1));
+
+          return 0;
+        }
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type                    | Message                                                                                                                         |
+      | PossiblyInvalidArgument | Argument 2 of sprintf expects float\|int\|string, possibly different type array<array-key, string>\|bool\|null\|string provided |
+    And I see no other errors


### PR DESCRIPTION
fixes https://github.com/psalm/psalm-plugin-symfony/issues/26