### PR TITLE
[RepositoryStringShortcut] complain when argument is string only

### DIFF
--- a/src/Handler/ClassHandler.php
+++ b/src/Handler/ClassHandler.php
@@ -5,6 +5,7 @@ namespace Psalm\SymfonyPsalmPlugin\Handler;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Scalar\String_;
 use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\Context;
@@ -72,7 +73,7 @@ class ClassHandler implements AfterClassLikeAnalysisInterface, AfterMethodCallAn
                 break;
             case 'Doctrine\ORM\EntityManagerInterface::getrepository':
             case 'Doctrine\Persistence\ObjectManager::getrepository':
-                if (!$expr->args[0]->value instanceof ClassConstFetch) {
+                if ($expr->args[0]->value instanceof String_ ) {
                     IssueBuffer::accepts(
                         new RepositoryStringShortcut(new CodeLocation($statements_source, $expr->args[0]->value)),
                         $statements_source->getSuppressedIssues()

--- a/tests/acceptance/acceptance/RepositoryStringShortcut.feature
+++ b/tests/acceptance/acceptance/RepositoryStringShortcut.feature
@@ -22,20 +22,9 @@ Feature: RepositoryStringShortcut
         </plugins>
       </psalm>
       """
-
-  Scenario: Asserting using 'AppBundle:Entity' syntax raises issue
-    Given I have the following code
+    And I have the following code preamble
       """
       <?php
-      use Doctrine\ORM\EntityManagerInterface;
-      class SomeService
-      {
-        public function __construct(EntityManagerInterface $entityManager)
-        {
-          $entityManager->getRepository('AppBundle:Entity');
-        }
-      }
-
       namespace Doctrine\ORM;
       interface EntityManagerInterface
       {
@@ -47,8 +36,50 @@ Feature: RepositoryStringShortcut
         public function getRepository($className);
       }
       """
+
+  Scenario: Asserting using 'AppBundle:Entity' syntax raises issue
+    Given I have the following code
+      """
+      use Doctrine\ORM\EntityManagerInterface;
+      class SomeService
+      {
+        public function __construct(EntityManagerInterface $entityManager)
+        {
+          $entityManager->getRepository('AppBundle:Entity');
+        }
+      }
+      """
     When I run Psalm
     Then I see these errors
       | Type                       | Message                            |
       | RepositoryStringShortcut  | Use Entity::class syntax instead |
     And I see no other errors
+
+  Scenario: Asserting using 'Entity::class' notation does not raise issue
+    Given I have the following code
+      """
+      class SomeService
+      {
+        public function __construct(EntityManagerInterface $entityManager)
+        {
+          $entityManager->getRepository(Entity::class);
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Dynamic repository calls should not be complained
+    Given I have the following code
+      """
+      class SomeService
+      {
+        public function __construct(EntityManagerInterface $entityManager)
+        {
+          $className = 'App\Entity\EntityA';
+          $entityManager->getRepository($className);
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/acceptance/RequestContent.feature
+++ b/tests/acceptance/acceptance/RequestContent.feature
@@ -16,14 +16,15 @@ Feature: Request getContent
         </plugins>
       </psalm>
       """
+    And I have the following code preamble
+      """
+      <?php
+      use Symfony\Component\HttpFoundation\Request;
+      """
 
   Scenario: Asserting '$request->getContent()' without any argument returns string
     Given I have the following code
       """
-      <?php
-
-      use Symfony\Component\HttpFoundation\Request;
-
       class App
       {
         public function index(Request $request): void
@@ -38,10 +39,6 @@ Feature: Request getContent
   Scenario: Asserting '$request->getContent(false)' returns string
     Given I have the following code
       """
-      <?php
-
-      use Symfony\Component\HttpFoundation\Request;
-
       class App
       {
         public function index(Request $request): void
@@ -56,10 +53,6 @@ Feature: Request getContent
   Scenario: Asserting '$request->getContent(true)' returns resource
     Given I have the following code
       """
-      <?php
-
-      use Symfony\Component\HttpFoundation\Request;
-
       class App
       {
         public function index(Request $request): void


### PR DESCRIPTION
fixes https://github.com/psalm/psalm-plugin-symfony/issues/32