### PR TITLE
Taint Request::get and Response::__construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ to use InputArgument and InputOption constants as a part of best practise.
 - Fixes `PossiblyInvalidArgument` for `Symfony\Component\HttpFoundation\Request::getContent`.
 The plugin calculates real return type by checking the given argument and marks return type as either string or resource.
 - Detect return type of `Symfony\Component\HttpFoundation\HeaderBag::get` (by checking default value and third argument for < Symfony 4.4)
+- Taint analysis for Symfony
 - Detects service [naming convention](https://symfony.com/doc/current/contributing/code/standards.html#naming-conventions) violations
 - Complains when `Container` is injected to a service. Use dependency-injection.
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1",
         "ext-simplexml": "*",
         "symfony/framework-bundle": "^3.0 || ^4.0 || ^5.0",
-        "vimeo/psalm": "^3.11.4"
+        "vimeo/psalm": "^3.12"
     },
     "require-dev": {
         "codeception/base": "^2.5",

--- a/src/Stubs/Request.stubphp
+++ b/src/Stubs/Request.stubphp
@@ -18,4 +18,14 @@ class Request
      * )
      */
     public function getContent($asResource = false) {}
+
+    /**
+     * Gets a "parameter" value from any bag.
+     *
+     * @param string $key     The key
+     * @param mixed  $default The default value if the parameter key does not exist
+     *
+     * @psalm-taint-source input
+     */
+    public function get($key, $default = null) {}
 }

--- a/src/Stubs/Response.stubphp
+++ b/src/Stubs/Response.stubphp
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+class Response
+{
+    /**
+     * @throws \InvalidArgumentException When the HTTP status code is not valid
+     * @psalm-taint-sink html $content
+     */
+    public function __construct($content = '', int $status = 200, array $headers = []) {}
+}

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -1,0 +1,41 @@
+Feature: Tainting
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
+      """
+      <?php
+
+      use Symfony\Component\HttpFoundation\Request;
+      use Symfony\Component\HttpFoundation\Response;
+      """
+
+    Scenario: One parameter of the Request is used in the body of a Response object
+      Given I have the following code
+        """
+        class MyController
+        {
+          public function __invoke(Request $request): Response
+          {
+            return new Response($request->get('untrusted'));
+          }
+        }
+        """
+      When I run Psalm with taint analysis
+      Then I see these errors
+        | Type                        | Message                                                     |
+        | TaintedInput | Detected tainted html |
+      And I see no other errors
+


### PR DESCRIPTION
Adding `Symfony\Component\HttpFoundation\Request::get` as a taint source and `Symfony\Component\HttpFoundation\Response::__construct` as a taint sink.

This is a work in progress, we should also add other sources and sinks :)