### PR TITLE
Add envelope stub to provide the correct argument and return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ to use InputArgument and InputOption constants as a part of best practise.
 - Fixes `PossiblyInvalidArgument` for `Symfony\Component\HttpFoundation\Request::getContent`.
 The plugin calculates real return type by checking the given argument and marks return type as either string or resource.
 - Detect return type of `Symfony\Component\HttpFoundation\HeaderBag::get` (by checking default value and third argument for < Symfony 4.4)
+- Detect return type of `Symfony\Component\Messenger\Envelope::last` and `Symfony\Component\Messenger\Envelope::all`, based on the provided argument.
 - Taint analysis for Symfony
 - Detects service and parameter [naming convention](https://symfony.com/doc/current/contributing/code/standards.html#naming-conventions) violations
 - Complains when `Container` is injected to a service. Use dependency-injection.

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "doctrine/orm": "^2.7",
         "phpunit/phpunit": "~7.5",
         "symfony/console": "*",
+        "symfony/messenger": "*",
         "weirdan/codeception-psalm-module": "~0.8"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/orm": "^2.7",
         "phpunit/phpunit": "~7.5",
         "symfony/console": "*",
-        "symfony/messenger": "*",
+        "symfony/messenger": "^4.2 || ^5.0",
         "weirdan/codeception-psalm-module": "~0.8"
     },
     "autoload": {

--- a/src/Stubs/Envelope.stubphp
+++ b/src/Stubs/Envelope.stubphp
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Component\Messenger;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+class Envelope
+{
+    /**
+     * @template T of StampInterface
+     * @psalm-param class-string<T> $stampFqcn
+     * @psalm-return ?T
+     */
+    public function last(string $stampFqcn): ?StampInterface {}
+
+    /**
+     * @template T of StampInterface
+     * @psalm-param class-string<T>|null $stampFqcn
+     * @psalm-return (
+     *     $stampFqcn is string
+     *     ? list<T>
+     *     : array<class-string<StampInterface>, list<StampInterface>>
+     * )
+     */
+    public function all(string $stampFqcn = null): array {}
+}

--- a/tests/acceptance/acceptance/Envelope.feature
+++ b/tests/acceptance/acceptance/Envelope.feature
@@ -1,0 +1,96 @@
+Feature: Messenger Envelope
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+
+        <plugins>
+          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
+      """
+      <?php
+
+      use Symfony\Component\Messenger\Envelope;
+      use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+
+      $envelope = new Envelope(new stdClass());
+      """
+
+  Scenario: Envelope::last() expects a class name implementing StampInterface
+    Given I have the following code
+      """
+      $stamp = $envelope->last(Symfony\Component\Messenger\Worker::class);
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message                                                                                                                                                                             |
+      | InvalidArgument | Argument 1 of Symfony\Component\Messenger\Envelope::last expects class-string<Symfony\Component\Messenger\Stamp\StampInterface>, Symfony\Component\Messenger\Worker::class provided |
+    And I see no other errors
+
+  Scenario: Envelope::last() returns a nullable object of the provided class name
+    Given I have the following code
+      """
+      $stamp = $envelope->last(ReceivedStamp::class);
+      if ($stamp !== null) {
+          $transport = $stamp->getTransportName();
+      }
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Envelope::all() expects a class name implementing StampInterface
+    Given I have the following code
+      """
+      $stamps = $envelope->all(Symfony\Component\Messenger\Worker::class);
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message                                                                                                                                                                                  |
+      | InvalidArgument | Argument 1 of Symfony\Component\Messenger\Envelope::all expects class-string<Symfony\Component\Messenger\Stamp\StampInterface>\|null, Symfony\Component\Messenger\Worker::class provided |
+    And I see no other errors
+
+  Scenario: Envelope::all() returns a list with objects of the provided class name
+    Given I have the following code
+      """
+      $stamps = $envelope->all(ReceivedStamp::class);
+      foreach ($stamps as $stamp) {
+          $transport = $stamp->getTransportName();
+      }
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Envelope::all() does not have a required argument
+    Given I have the following code
+      """
+      $stamps = $envelope->all();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Envelope::all() returns a nested array when no argument is provided
+    Given I have the following code
+      """
+      $stamps = $envelope->all();
+      foreach ($stamps as $className => $classStamps) {
+          foreach ($classStamps as $stamp) {
+              if ($stamp instanceof Symfony\Component\Messenger\Stamp\StampInterface) {
+                  echo 'always true';
+              }
+          }
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type                                | Message                                                                                                                                                                                                      |
+      | RedundantConditionGivenDocblockType | Found a redundant condition when evaluating docblock-defined type $stamp and trying to reconcile type 'Symfony\Component\Messenger\Stamp\StampInterface' to Symfony\Component\Messenger\Stamp\StampInterface |
+    And I see no other errors

--- a/tests/acceptance/acceptance/Envelope.feature
+++ b/tests/acceptance/acceptance/Envelope.feature
@@ -20,7 +20,15 @@ Feature: Messenger Envelope
       <?php
 
       use Symfony\Component\Messenger\Envelope;
-      use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+      use Symfony\Component\Messenger\Stamp\StampInterface;
+
+      class TestStamp implements StampInterface
+      {
+          public function getDummy(): string
+          {
+              return 'dummy';
+          }
+      }
 
       $envelope = new Envelope(new stdClass());
       """
@@ -39,9 +47,9 @@ Feature: Messenger Envelope
   Scenario: Envelope::last() returns a nullable object of the provided class name
     Given I have the following code
       """
-      $stamp = $envelope->last(ReceivedStamp::class);
+      $stamp = $envelope->last(TestStamp::class);
       if ($stamp !== null) {
-          $transport = $stamp->getTransportName();
+          $dummy = $stamp->getDummy();
       }
       """
     When I run Psalm
@@ -61,9 +69,9 @@ Feature: Messenger Envelope
   Scenario: Envelope::all() returns a list with objects of the provided class name
     Given I have the following code
       """
-      $stamps = $envelope->all(ReceivedStamp::class);
+      $stamps = $envelope->all(TestStamp::class);
       foreach ($stamps as $stamp) {
-          $transport = $stamp->getTransportName();
+          $dummy = $stamp->getDummy();
       }
       """
     When I run Psalm
@@ -83,7 +91,7 @@ Feature: Messenger Envelope
       $stamps = $envelope->all();
       foreach ($stamps as $className => $classStamps) {
           foreach ($classStamps as $stamp) {
-              if ($stamp instanceof Symfony\Component\Messenger\Stamp\StampInterface) {
+              if ($stamp instanceof StampInterface) {
                   echo 'always true';
               }
           }


### PR DESCRIPTION
This pull request adds a stub for the Envelope class in the Messenger component (the `last` and `all` methods).

This enables Psalm to verify the correct argument type and provides information about the return type.