### PR TITLE
Tainting

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,6 +11,7 @@ use Psalm\SymfonyPsalmPlugin\Handler\ContainerHandler;
 use Psalm\SymfonyPsalmPlugin\Handler\DoctrineRepositoryHandler;
 use Psalm\SymfonyPsalmPlugin\Handler\HeaderBagHandler;
 use Psalm\SymfonyPsalmPlugin\Symfony\ContainerMeta;
+use Psalm\SymfonyPsalmPlugin\Taint\RequestTaint;
 use SimpleXMLElement;
 
 /**
@@ -48,5 +49,8 @@ class Plugin implements PluginEntryPointInterface
         foreach (glob(__DIR__.'/Stubs/*.stubphp') as $stubFilePath) {
             $api->addStubFile($stubFilePath);
         }
+
+        require_once __DIR__.'/Taint/RequestTaint.php';
+        $api->registerHooksFromClass(RequestTaint::class);
     }
 }

--- a/src/Stubs/HeaderBag.stubphp
+++ b/src/Stubs/HeaderBag.stubphp
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * HeaderBag is a container for HTTP headers.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HeaderBag implements \IteratorAggregate, \Countable
+{
+    /**
+     * Returns the headers as a string.
+     *
+     * @return string The headers
+     *
+     * @psalm-taint-source input
+     */
+    public function __toString() {}
+}

--- a/src/Stubs/InputBag.stubphp
+++ b/src/Stubs/InputBag.stubphp
@@ -16,4 +16,15 @@ final class InputBag extends ParameterBag
      * @psalm-taint-source input
      */
     public function get(string $key, $default = null) {}
+
+    /**
+     * Returns the parameters.
+     *
+     * @param string|null $key The name of the parameter to return or null to get them all
+     *
+     * @return array An array of parameters
+     *
+     * @psalm-taint-source input
+     */
+    public function all(string $key = null) {}
 }

--- a/src/Stubs/InputBag.stubphp
+++ b/src/Stubs/InputBag.stubphp
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+
+final class InputBag extends ParameterBag
+{
+    /**
+     * Returns a string input value by name.
+     *
+     * @param string|null $default The default value if the input key does not exist
+     *
+     * @return string|null
+     *
+     * @psalm-taint-source input
+     */
+    public function get(string $key, $default = null) {}
+}

--- a/src/Taint/RequestTaint.php
+++ b/src/Taint/RequestTaint.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\SymfonyPsalmPlugin\Taint;
+
+
+use PhpParser\Node\Expr;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\FileManipulation;
+use Psalm\Internal\Analyzer\Statements\Expression\ExpressionIdentifier;
+use Psalm\Issue\TaintedInput;
+use Psalm\IssueBuffer;
+use Psalm\Plugin\Hook\AfterExpressionAnalysisInterface;
+use Psalm\StatementsSource;
+use PhpParser\PrettyPrinter\Standard;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+class RequestTaint implements AfterExpressionAnalysisInterface
+{
+
+    public static function afterExpressionAnalysis(Expr $expr, Context $context, StatementsSource $statements_source, Codebase $codebase, array &$file_replacements = [])
+    {
+        if(!$expr instanceof Expr\MethodCall || strval($expr->name) !== 'get') {
+            return;
+        }
+
+        $contextVariableName = ExpressionIdentifier::getVarId($expr->var, null);
+        if(!array_key_exists($contextVariableName, $context->vars_in_scope)) {
+            throw new RuntimeException(sprintf('Type of %s can not be determined because it was not found in context.', $contextVariableName));
+        }
+
+        $types = array_keys($context->vars_in_scope[$contextVariableName]->getAtomicTypes());
+        if(!in_array(HeaderBag::class, $types)) {
+            return;
+        }
+
+        $headerName = strtolower($expr->args[0]->value->value);
+        if($headerName !== 'user-agent') {
+            return;
+        }
+
+        IssueBuffer::accepts(new TaintedInput('Detected tainted header', new CodeLocation($statements_source, $expr)));
+    }
+}

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -39,7 +39,6 @@ Feature: Tainting
       | TaintedInput | Detected tainted html |
     And I see no other errors
 
-
   Scenario: One parameter of the Request's request is used in the body of a Response object
     Given I have the following code
       """
@@ -104,6 +103,24 @@ Feature: Tainting
       """
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message                 |
-      | TaintedInput | Detected tainted header |
+      | Type         | Message               |
+      | TaintedInput | Detected tainted html |
+    And I see no other errors
+
+  Scenario: All headers are printed in the body of a Response object
+    Given I have the following code
+      """
+      class MyController
+      {
+        public function __invoke(Request $request): Response
+        {
+          return new Response((string) $request->headers);
+        }
+      }
+      """
+    And I have Psalm newer than "3.12.1" (because of "string casting")
+    When I run Psalm with taint analysis
+    Then I see these errors
+      | Type         | Message               |
+      | TaintedInput | Detected tainted html |
     And I see no other errors

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -22,20 +22,72 @@ Feature: Tainting
       use Symfony\Component\HttpFoundation\Response;
       """
 
-    Scenario: One parameter of the Request is used in the body of a Response object
-      Given I have the following code
-        """
-        class MyController
+  Scenario: One parameter of the Request is used in the body of a Response object
+    Given I have the following code
+      """
+      class MyController
+      {
+        public function __invoke(Request $request): Response
         {
-          public function __invoke(Request $request): Response
-          {
-            return new Response($request->get('untrusted'));
-          }
+          return new Response($request->get('untrusted'));
         }
-        """
-      When I run Psalm with taint analysis
-      Then I see these errors
-        | Type                        | Message                                                     |
-        | TaintedInput | Detected tainted html |
-      And I see no other errors
+      }
+      """
+    When I run Psalm with taint analysis
+    Then I see these errors
+      | Type         | Message               |
+      | TaintedInput | Detected tainted html |
+    And I see no other errors
+
+
+  Scenario: One parameter of the Request's request is used in the body of a Response object
+    Given I have the following code
+      """
+      class MyController
+      {
+        public function __invoke(Request $request): Response
+        {
+          return new Response($request->request->get('untrusted'));
+        }
+      }
+      """
+    When I run Psalm with taint analysis
+    Then I see these errors
+      | Type         | Message               |
+      | TaintedInput | Detected tainted html |
+    And I see no other errors
+
+  Scenario: One parameter of the Request's query is used in the body of a Response object
+    Given I have the following code
+      """
+      class MyController
+      {
+        public function __invoke(Request $request): Response
+        {
+          return new Response($request->query->get('untrusted'));
+        }
+      }
+      """
+    When I run Psalm with taint analysis
+    Then I see these errors
+      | Type         | Message               |
+      | TaintedInput | Detected tainted html |
+    And I see no other errors
+
+  Scenario: One parameter of the Request's cookie is used in the body of a Response object
+    Given I have the following code
+      """
+      class MyController
+      {
+        public function __invoke(Request $request): Response
+        {
+          return new Response($request->cookies->get('untrusted'));
+        }
+      }
+      """
+    When I run Psalm with taint analysis
+    Then I see these errors
+      | Type         | Message               |
+      | TaintedInput | Detected tainted html |
+    And I see no other errors
 

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -39,14 +39,14 @@ Feature: Tainting
       | TaintedInput | Detected tainted html |
     And I see no other errors
 
-  Scenario: One parameter of the Request's request is used in the body of a Response object
+  Scenario Outline: One parameter of the Request's request/query/cookies is used in the body of a Response object
     Given I have the following code
       """
       class MyController
       {
         public function __invoke(Request $request): Response
         {
-          return new Response($request->request->get('untrusted'));
+          return new Response($request-><property>->get('untrusted'));
         }
       }
       """
@@ -55,15 +55,20 @@ Feature: Tainting
       | Type         | Message               |
       | TaintedInput | Detected tainted html |
     And I see no other errors
+    Examples:
+      | property |
+      | request  |
+      | query    |
+      | cookies  |
 
-  Scenario: One parameter of the Request's query is used in the body of a Response object
+  Scenario Outline: All parameters of the Request's request/query/cookies are exported in the body of a Response object
     Given I have the following code
       """
       class MyController
       {
         public function __invoke(Request $request): Response
         {
-          return new Response($request->query->get('untrusted'));
+          return new Response(var_export($request-><property>->all(), true));
         }
       }
       """
@@ -72,23 +77,11 @@ Feature: Tainting
       | Type         | Message               |
       | TaintedInput | Detected tainted html |
     And I see no other errors
-
-  Scenario: One parameter of the Request's cookie is used in the body of a Response object
-    Given I have the following code
-      """
-      class MyController
-      {
-        public function __invoke(Request $request): Response
-        {
-          return new Response($request->cookies->get('untrusted'));
-        }
-      }
-      """
-    When I run Psalm with taint analysis
-    Then I see these errors
-      | Type         | Message               |
-      | TaintedInput | Detected tainted html |
-    And I see no other errors
+    Examples:
+      | property |
+      | request  |
+      | query    |
+      | cookies  |
 
   Scenario: The user-agent is used in the body of a Response object
     Given I have the following code

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -91,3 +91,19 @@ Feature: Tainting
       | TaintedInput | Detected tainted html |
     And I see no other errors
 
+  Scenario: The user-agent is used in the body of a Response object
+    Given I have the following code
+      """
+      class MyController
+      {
+        public function __invoke(Request $request): Response
+        {
+          return new Response($request->headers->get('user-agent'));
+        }
+      }
+      """
+    When I run Psalm with taint analysis
+    Then I see these errors
+      | Type         | Message                 |
+      | TaintedInput | Detected tainted header |
+    And I see no other errors


### PR DESCRIPTION
Adding taint sources : 

- `Symfony\Component\HttpFoundation\InputBag::get` and `Symfony\Component\HttpFoundation\InputBag::all` (reachable via `Symfony\Component\HttpFoundation\Request::$request`, `Symfony\Component\HttpFoundation\Request::$query`, and `Symfony\Component\HttpFoundation\Request::$cookies`) 
- `Symfony\Component\HttpFoundation\HeaderBag::__toString` and `Symfony\Component\HttpFoundation\HeaderBag::get` (reachable via by `Symfony\Component\HttpFoundation\Request::$headers`) but only when the argument is `user-agent`in the second case.
- `Symfony\Component\HttpFoundation\HeaderBag::__toString` (reachable via by `Symfony\Component\HttpFoundation\Request::$headers`).

Open questions (i will try to answer them myself, but if someone want to give advices) : 
 - should we add a taint source for doctrine _inserts/updates_ ? what about _selects_ ?
 - should we try to add twig _render_ as taint source ? if so, i'm not sure to know how to taint it..
 - are there other component to consider ? _process_ maybe..
 - we should try to also have `ParameterBag::filter` as source, but i'm not sure of how to proceed (only with an annotation or with an handler)..