### PR TITLE
removed .gitkeep & unblocked testing on symfony 5.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 composer.lock
 .php_cs.cache
 tests/_run
+/.idea

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "vimeo/psalm": "^3.12"
     },
     "require-dev": {
-        "codeception/base": "^2.5",
         "doctrine/orm": "^2.7",
         "phpunit/phpunit": "~7.5",
         "symfony/console": "*",


### PR DESCRIPTION
1. `.gitkeep` files are no longer needed in order to keep an empty folder in git
2. Dev dependency `codeception/base` was causing symfony components to be restricted by `<5.0` version (via `symfony/console < 5.0` requirement). **Therefore tests were actually never run on Symfony 5.\* framework.**
The `codeception/base` itself is **archived** on github and marked **obsolete**.
Moreover, the other `weirdan/codeception-psalm-module` dependency installs a proper up-to-date `codeception/codeception` package, so no other changes in the `composer.json` are required.