### PR TITLE
totallyTyped is deprecated, changed to errorLevel="1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ The plugin calculates real return type by checking the given argument and marks 
 
 ### Configuration
 
-If you followed installation instructions, psalm-plugin command would added plugin configuration to psalm.xml
+If you follow installation instructions, psalm-plugin command will add plugin configuration to psalm.xml
 
 ```xml
 <?xml version="1.0"?>
-<psalm totallyTyped="true">
+<psalm errorLevel="1">
     <!--  project configuration -->
 
     <plugins>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/tests/acceptance/acceptance/ConsoleArgument.feature
+++ b/tests/acceptance/acceptance/ConsoleArgument.feature
@@ -4,7 +4,7 @@ Feature: ConsoleArgument
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/acceptance/ConsoleOption.feature
+++ b/tests/acceptance/acceptance/ConsoleOption.feature
@@ -4,7 +4,7 @@ Feature: ConsoleOption
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/acceptance/ContainerDependency.feature
+++ b/tests/acceptance/acceptance/ContainerDependency.feature
@@ -7,7 +7,7 @@ Feature: ContainerDependency
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/acceptance/ContainerService.feature
+++ b/tests/acceptance/acceptance/ContainerService.feature
@@ -5,7 +5,7 @@ Feature: Container service
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/acceptance/ContainerXml.feature
+++ b/tests/acceptance/acceptance/ContainerXml.feature
@@ -5,7 +5,7 @@ Feature: Container XML config
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/acceptance/Envelope.feature
+++ b/tests/acceptance/acceptance/Envelope.feature
@@ -4,7 +4,7 @@ Feature: Messenger Envelope
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/acceptance/HeaderBag.feature
+++ b/tests/acceptance/acceptance/HeaderBag.feature
@@ -4,7 +4,7 @@ Feature: Header get
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/acceptance/NamingConventions.feature
+++ b/tests/acceptance/acceptance/NamingConventions.feature
@@ -5,7 +5,7 @@ Feature: Naming conventions
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/acceptance/RepositoryStringShortcut.feature
+++ b/tests/acceptance/acceptance/RepositoryStringShortcut.feature
@@ -7,7 +7,7 @@ Feature: RepositoryStringShortcut
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/acceptance/RequestContent.feature
+++ b/tests/acceptance/acceptance/RequestContent.feature
@@ -5,7 +5,7 @@ Feature: Request getContent
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -4,7 +4,7 @@ Feature: Tainting
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>


### PR DESCRIPTION
Please see [the documentation](https://psalm.dev/docs/running_psalm/configuration/#totallytyped)

> (Deprecated) Setting totallyTyped to "true" is equivalent to setting errorLevel to "1".