### PR TITLE
Added stub for PropertyAccessorInterface::setValue()

### DIFF
--- a/src/Stubs/common/PropertyAccessorInterface.stubphp
+++ b/src/Stubs/common/PropertyAccessorInterface.stubphp
@@ -1,0 +1,39 @@
+<?php
+
+namespace Symfony\Component\PropertyAccess;
+
+interface PropertyAccessorInterface
+{
+    /**
+     * @template T as object|array
+     * @psalm-param T $objectOrArray
+     * @psalm-param string|PropertyPathInterface $propertyPath
+     * @psalm-param mixed $value
+     * @psalm-out T $objectOrArray
+     */
+    public function setValue(&$objectOrArray, $propertyPath, $value);
+
+    /**
+     * @param object|array $objectOrArray
+     * @param string|PropertyPathInterface $propertyPath
+     *
+     * @return mixed
+     */
+    public function getValue($objectOrArray, $propertyPath);
+
+    /**
+     * @param object|array $objectOrArray
+     * @param string|PropertyPathInterface $propertyPath
+     *
+     * @return bool
+     */
+    public function isWritable($objectOrArray, $propertyPath);
+
+    /**
+     * @param object|array $objectOrArray
+     * @param string|PropertyPathInterface $propertyPath
+     *
+     * @return bool
+     */
+    public function isReadable($objectOrArray, $propertyPath);
+}

--- a/src/Stubs/common/PropertyAccessorInterface.stubphp
+++ b/src/Stubs/common/PropertyAccessorInterface.stubphp
@@ -9,7 +9,7 @@ interface PropertyAccessorInterface
      * @psalm-param T $objectOrArray
      * @psalm-param string|PropertyPathInterface $propertyPath
      * @psalm-param mixed $value
-     * @psalm-out T $objectOrArray
+     * @psalm-self-out T $objectOrArray
      */
     public function setValue(&$objectOrArray, $propertyPath, $value);
 

--- a/tests/acceptance/acceptance/PropertyAccessorInterface.feature
+++ b/tests/acceptance/acceptance/PropertyAccessorInterface.feature
@@ -1,0 +1,53 @@
+@symfony-common
+Feature: PropertyAccessorInterface
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm errorLevel="1">
+        <projectFiles>
+          <directory name="."/>
+        </projectFiles>
+
+        <plugins>
+          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
+      """
+      <?php
+
+      use Symfony\Component\PropertyAccess\PropertyAccess;
+
+      $propertyAccessor = PropertyAccess::createPropertyAccessor();
+      """
+
+  Scenario: Set value keeps array type if array is passed
+    Given I have the following code
+      """
+      $company = ['name' => 'Acme'];
+
+      $propertyAccessor->setValue($company, 'name', 'Acme v2');
+
+      array_key_exists('name', $company);
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Set value keeps object instance if an object is passed
+    Given I have the following code
+      """
+      class Company
+      {
+          public string $name = 'Acme';
+      }
+      $company = new Company();
+
+      $propertyAccessor->setValue($company, 'name', 'Acme v2');
+
+      echo $company->name;
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
The passed-by reference `$objectOrArray` parameter of `setValue()` keeps the original type. I learned today that it is possible to specify this using `@psalm-out`, so I decided to contribute that to this plugin.

However, while I tested this stub successfully in a project of mime, I can't seem to make the tests working. Am I missing something somewhere?