### PR TITLE
Detect return type for denormalize and deserialize for the Serializer component

### DIFF
--- a/src/Stubs/common/DenormalizerInterface.stubphp
+++ b/src/Stubs/common/DenormalizerInterface.stubphp
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+/**
+ *
+ */
+interface DenormalizerInterface
+{
+    /**
+     * @template     T
+     * @psalm-param  class-string<T> $type
+     * @psalm-return T
+     */
+    public function denormalize($data, string $type, string $format = null, array $context = []);
+
+    /**
+     * @template    T
+     * @psalm-param class-string<T> $type
+     */
+    public function supportsDenormalization($data, string $type, string $format = null);
+}

--- a/src/Stubs/common/DenormalizerInterface.stubphp
+++ b/src/Stubs/common/DenormalizerInterface.stubphp
@@ -2,9 +2,6 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
-/**
- *
- */
 interface DenormalizerInterface
 {
     /**

--- a/src/Stubs/common/SerializerInterface.stubphp
+++ b/src/Stubs/common/SerializerInterface.stubphp
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Serializer;
+
+interface SerializerInterface
+{
+    /**
+     * @template     T
+     * @psalm-param  class-string<T> $type
+     * @psalm-return T
+     */
+    public function deserialize($data, string $type, string $format, array $context = []);
+}

--- a/tests/acceptance/acceptance/DenormalizerInterface.feature
+++ b/tests/acceptance/acceptance/DenormalizerInterface.feature
@@ -1,0 +1,43 @@
+@symfony-common
+Feature: Denormalizer interface
+  Detect DenormalizerInterface::denormalize() result type
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm errorLevel="1">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+
+        <plugins>
+          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+
+  Scenario: Asserting psalm recognizes return type
+    Given I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      class SomeService
+      {
+        public function foo(): void {}
+      }
+
+      class SomeController
+      {
+        public function __construct(DenormalizerInterface $denormalizer)
+        {
+          $someService = $denormalizer->denormalize([], SomeService::class);
+
+          $someService->foo();
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/acceptance/SerializerInterface.feature
+++ b/tests/acceptance/acceptance/SerializerInterface.feature
@@ -1,6 +1,6 @@
 @symfony-common
-Feature: Denormalizer interface
-  Detect DenormalizerInterface::denormalize() result type
+Feature: Serializer interface
+  Detect SerializerInterface::deserialize() result type
 
   Background:
     Given I have the following config

--- a/tests/acceptance/acceptance/SerializerInterface.feature
+++ b/tests/acceptance/acceptance/SerializerInterface.feature
@@ -1,0 +1,43 @@
+@symfony-common
+Feature: Denormalizer interface
+  Detect DenormalizerInterface::denormalize() result type
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm errorLevel="1">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+
+        <plugins>
+          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+
+  Scenario: Asserting psalm recognizes return type
+    Given I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\SerializerInterface;
+
+      class SomeService
+      {
+        public function foo(): void {}
+      }
+
+      class SomeController
+      {
+        public function __construct(SerializerInterface $serializer)
+        {
+          $someService = $serializer->deserialize('[]', SomeService::class, 'json');
+
+          $someService->foo();
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
This adds support for detecting the return type for `DenormalizerInterface::denormalize()` and `SerializerInterface::deserialize()` based on the `$type` argument of these methods.