### PR TITLE
Fix the precedence of the CachedTemplatesMapping & allow alternative template naming

### DIFF
--- a/src/Twig/CachedTemplateNotFoundException.php
+++ b/src/Twig/CachedTemplateNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\SymfonyPsalmPlugin\Twig;
+
+use Exception;
+
+class CachedTemplateNotFoundException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('No cache found for template with name(s) :');
+    }
+
+    public function addTriedName(string $possibleName): void
+    {
+        $this->message .= ' '.$possibleName;
+    }
+}

--- a/src/Twig/CachedTemplatesMapping.php
+++ b/src/Twig/CachedTemplatesMapping.php
@@ -5,68 +5,68 @@ declare(strict_types=1);
 namespace Psalm\SymfonyPsalmPlugin\Twig;
 
 use Psalm\Codebase;
-use Psalm\Context;
-use Psalm\Plugin\Hook\AfterFileAnalysisInterface;
-use Psalm\StatementsSource;
-use Psalm\Storage\FileStorage;
+use Psalm\Plugin\Hook\AfterCodebasePopulatedInterface;
 use RuntimeException;
 
 /**
  * This class is used to store a mapping of all analyzed twig template cache files with their corresponding actual templates.
  */
-class CachedTemplatesMapping implements AfterFileAnalysisInterface
+class CachedTemplatesMapping implements AfterCodebasePopulatedInterface
 {
     /**
      * @var string
      */
-    private const CACHED_TEMPLATE_HEADER_PATTERN = 'use Twig\\\\Template;\n\n\/\* (@?.+\.twig) \*\/\nclass __TwigTemplate';
+    public const CACHED_TEMPLATE_HEADER_PATTERN =
+        'use Twig\\\\Template;\n\n'.
+        '\/\* (?<name>@?.+\.twig) \*\/\n'.
+        'class (?<class>__TwigTemplate_[a-z0-9]{64}) extends (\\\\Twig\\\\)?Template';
 
     /**
      * @var string|null
      */
-    public static $cache_path;
+    private static $cachePath;
 
     /**
-     * @var array<string, string>
+     * @var CachedTemplatesRegistry|null
      */
-    private static $mapping = [];
+    private static $cacheRegistry;
 
-    public static function afterAnalyzeFile(StatementsSource $statements_source, Context $file_context, FileStorage $file_storage, Codebase $codebase): void
+    public static function afterCodebasePopulated(Codebase $codebase)
     {
-        if (null === self::$cache_path || 0 !== strpos($file_storage->file_path, self::$cache_path)) {
+        if (null === self::$cachePath) {
             return;
         }
 
-        $rawSource = file_get_contents($file_storage->file_path);
-        if (!preg_match('/'.self::CACHED_TEMPLATE_HEADER_PATTERN.'/m', $rawSource, $matchingParts)) {
-            return;
+        self::$cacheRegistry = new CachedTemplatesRegistry();
+        $cacheFiles = $codebase->file_provider->getFilesInDir(self::$cachePath, ['php']);
+
+        foreach ($cacheFiles as $file) {
+            $rawSource = $codebase->file_provider->getContents($file);
+
+            if (!preg_match('/'.self::CACHED_TEMPLATE_HEADER_PATTERN.'/m', $rawSource, $matchingParts)) {
+                continue;
+            }
+            $templateName = $matchingParts['name'];
+            $cacheClassName = $matchingParts['class'];
+
+            self::$cacheRegistry->addTemplate($cacheClassName, $templateName);
         }
-
-        /** @var string|null $cacheClassName */
-        [$cacheClassName] = array_values($file_storage->classlikes_in_file);
-        if (null === $cacheClassName) {
-            return;
-        }
-
-        self::registerNewCache($cacheClassName, $matchingParts[1]);
     }
 
-    public static function setCachePath(string $cache_path): void
+    public static function setCachePath(string $cachePath): void
     {
-        static::$cache_path = $cache_path;
+        self::$cachePath = $cachePath;
     }
 
-    private static function registerNewCache(string $cacheClassName, string $templateName): void
-    {
-        static::$mapping[$templateName] = $cacheClassName;
-    }
-
+    /**
+     * @throws CachedTemplateNotFoundException
+     */
     public static function getCacheClassName(string $templateName): string
     {
-        if (!array_key_exists($templateName, static::$mapping)) {
-            throw new RuntimeException(sprintf('The template %s was not found.', $templateName));
+        if (null === self::$cacheRegistry) {
+            throw new RuntimeException(sprintf('Can not load template %s, because no cache registry is provided.', $templateName));
         }
 
-        return static::$mapping[$templateName];
+        return self::$cacheRegistry->getCacheClassName($templateName);
     }
 }

--- a/src/Twig/CachedTemplatesRegistry.php
+++ b/src/Twig/CachedTemplatesRegistry.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\SymfonyPsalmPlugin\Twig;
+
+use Generator;
+
+class CachedTemplatesRegistry
+{
+    /**
+     * @var array<string, string>
+     */
+    private $mapping = [];
+
+    public function addTemplate(string $cacheClassName, string $templateName): void
+    {
+        $this->mapping[$templateName] = $cacheClassName;
+    }
+
+    /**
+     * @throws CachedTemplateNotFoundException
+     */
+    public function getCacheClassName(string $templateName): string
+    {
+        $probableException = new CachedTemplateNotFoundException();
+
+        foreach (self::generateNames($templateName) as $possibleName) {
+            if (array_key_exists($possibleName, $this->mapping)) {
+                return $this->mapping[$possibleName];
+            }
+            $probableException->addTriedName($possibleName);
+        }
+
+        throw $probableException;
+    }
+
+    /**
+     * @return Generator<string>
+     */
+    private static function generateNames(string $baseName): Generator
+    {
+        yield $baseName;
+
+        /** @var string|null $oldNotation */
+        $oldNotation = null;
+
+        $alternativeNotation = preg_replace('/^@([^\/]+)\/?(.+)?\/([^\/]+\.twig)/', '$1Bundle:$2:$3', $baseName);
+        if ($alternativeNotation !== $baseName) {
+            yield $alternativeNotation;
+            $oldNotation = $alternativeNotation;
+        }
+
+        $alternativeNotation = preg_replace('/^(.+)Bundle:(.+)?:(.+\.twig)$/', '@$1/$2/$3', $baseName);
+        if ($alternativeNotation !== $baseName) {
+            yield str_replace('//', '/', $alternativeNotation);
+            $oldNotation = $baseName;
+        }
+
+        if (null !== $oldNotation) {
+            list($bundleName, $rest) = explode(':', $oldNotation, 2);
+            list($revTemplateName, $revRest) = explode(':', strrev($rest), 2);
+            $pathParts = explode('/', strrev($revRest));
+            $pathParts = array_merge($pathParts, explode('/', strrev($revTemplateName)));
+            for ($i = 0; $i <= count($pathParts); ++$i) {
+                yield $bundleName.':'.
+                    implode('/', array_slice($pathParts, 0, $i)).':'.
+                    implode('/', array_slice($pathParts, $i));
+            }
+        }
+    }
+}

--- a/src/Twig/CachedTemplatesTainter.php
+++ b/src/Twig/CachedTemplatesTainter.php
@@ -56,7 +56,7 @@ class CachedTemplatesTainter implements MethodReturnTypeProviderInterface
             new Identifier(
                 'doDisplay'
             ),
-            [$call_args[1]]
+            isset($call_args[1]) ? [$call_args[1]] : []
         );
 
         $firstArgument = $call_args[0]->value;

--- a/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature
+++ b/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature
@@ -36,6 +36,20 @@ Feature: Twig tainting with analyzer
       function twig() {}
       """
 
+  Scenario: The twig rendering has no parameters
+    Given I have the following code
+      """
+      twig()->render('index.html.twig');
+      """
+    And I have the following "index.html.twig" template
+      """
+      <h1>
+        Nothing.
+      </h1>
+      """
+    When I run Psalm with taint analysis
+    And I see no errors
+
   Scenario: One parameter of the twig rendering is tainted but autoescaping is on
     Given I have the following code
       """

--- a/tests/unit/Twig/CachedTemplatesRegistryTest.php
+++ b/tests/unit/Twig/CachedTemplatesRegistryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\SymfonyPsalmPlugin\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\SymfonyPsalmPlugin\Twig\CachedTemplateNotFoundException;
+use Psalm\SymfonyPsalmPlugin\Twig\CachedTemplatesRegistry;
+
+class CachedTemplatesRegistryTest extends TestCase
+{
+    /**
+     * @dataProvider provideNotationsMatchingTemplateName
+     */
+    public function testNotationMatchingTemplateName(string $templateName, string $searchedName)
+    {
+        $registry = new CachedTemplatesRegistry();
+        $registry->addTemplate('expected_cache_class', $templateName);
+
+        self::assertSame('expected_cache_class', $registry->getCacheClassName($searchedName));
+    }
+
+    public function provideNotationsMatchingTemplateName(): array
+    {
+        return [
+            ['index.html.twig', 'index.html.twig'],
+            ['AcmeBundle::index.html.twig', '@Acme/index.html.twig'],
+            ['@Acme/index.html.twig', 'AcmeBundle::index.html.twig'],
+            ['AppBundle:DataProvider/GraduateJobs:job.xml.twig', '@App/DataProvider/GraduateJobs/job.xml.twig'],
+            ['AppBundle:Emails/workflow_status:default_email.html.twig', 'AppBundle:Emails:workflow_status/default_email.html.twig'],
+            ['AppBundle:Emails/workflow_status/foobar:default_email.html.twig', 'AppBundle:Emails:workflow_status/foobar/default_email.html.twig'],
+            ['AppBundle:Emails/workflow_status:foobar/default_email.html.twig', 'AppBundle:Emails:workflow_status/foobar/default_email.html.twig'],
+            ['AppBundle:Emails:workflow_status/foobar/default_email.html.twig', 'AppBundle:Emails/workflow_status:foobar/default_email.html.twig'],
+            ['AppBundle:Emails/workflow_status/foobar:default_email.html.twig', 'AppBundle:Emails/workflow_status:foobar/default_email.html.twig'],
+            ['AppBundle:Emails:workflow_status/foobar/default_email.html.twig', 'AppBundle:Emails/workflow_status/foobar:default_email.html.twig'],
+            ['AppBundle:Emails/workflow_status:foobar/default_email.html.twig', 'AppBundle:Emails/workflow_status/foobar:default_email.html.twig'],
+        ];
+    }
+
+    public function testNotationNotMatchingTemplateName()
+    {
+        $registry = new CachedTemplatesRegistry();
+        $registry->addTemplate('index.html.twig', 'not_expected_cache_class');
+
+        self::expectException(CachedTemplateNotFoundException::class);
+        $registry->getCacheClassName('');
+    }
+}


### PR DESCRIPTION
It tries to fix https://github.com/psalm/psalm-plugin-symfony/issues/84 and subsequent https://github.com/psalm/psalm-plugin-symfony/issues/90.

First modification : The `CachedTemplatesMapping` was a `AfterFileAnalysisInterface` hook and it is now a `AfterCodebasePopulatedInterface` hook to ensure it maps cache names before they are needed by the `CachedTemplatesTainter`. This is not tested becaus I did not manage to reproduce within the test suite context.

Second modification : The  `CachedTemplatesMapping` can now translate a `@Some/dir/file.twig` name to `SomeBundle:dir:file.twig` name and vice-versa. This is functionnaly tested but maybe it should also be unit tested (the translation logic I mean).

