### PR TITLE
Allow Twig\Environment::render to be tainted even when using variables as arguments.

### DIFF
--- a/src/Twig/CachedTemplatesTainter.php
+++ b/src/Twig/CachedTemplatesTainter.php
@@ -7,7 +7,6 @@ namespace Psalm\SymfonyPsalmPlugin\Twig;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Scalar\String_;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\MethodCallAnalyzer;
@@ -59,12 +58,8 @@ class CachedTemplatesTainter implements MethodReturnTypeProviderInterface
             isset($call_args[1]) ? [$call_args[1]] : []
         );
 
-        $firstArgument = $call_args[0]->value;
-        if (!$firstArgument instanceof String_) {
-            return null;
-        }
-
-        $cacheClassName = CachedTemplatesMapping::getCacheClassName($firstArgument->value);
+        $templateName = TwigUtils::extractTemplateNameFromExpression($call_args[0]->value, $source);
+        $cacheClassName = CachedTemplatesMapping::getCacheClassName($templateName);
 
         $context->vars_in_scope['$__fake_twig_env_var__'] = new Union([
             new TNamedObject($cacheClassName),

--- a/src/Twig/TemplateFileAnalyzer.php
+++ b/src/Twig/TemplateFileAnalyzer.php
@@ -11,6 +11,11 @@ use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\NodeTraverser;
 
+/**
+ * This class is to be used as a "checker" for the `.twig` files in the psalm configuration.
+ *
+ * @psalm-suppress UnusedClass
+ */
 class TemplateFileAnalyzer extends FileAnalyzer
 {
     public function analyze(

--- a/src/Twig/TwigUtils.php
+++ b/src/Twig/TwigUtils.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\SymfonyPsalmPlugin\Twig;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
+use Psalm\StatementsSource;
+use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Union;
+use RuntimeException;
+
+class TwigUtils
+{
+    public static function extractTemplateNameFromExpression(Expr $templateName, StatementsSource $source): string
+    {
+        if ($templateName instanceof Variable) {
+            $type = $source->getNodeTypeProvider()->getType($templateName) ?? new Union([new TNull()]);
+            $templateName = array_values($type->getAtomicTypes())[0];
+        }
+
+        if (!$templateName instanceof String_ && !$templateName instanceof TLiteralString) {
+            throw new RuntimeException(sprintf('Can not retrieve template name from given expression (%s)', get_class($templateName)));
+        }
+
+        return $templateName->value;
+    }
+}

--- a/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature
+++ b/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature
@@ -83,6 +83,26 @@ Feature: Twig tainting with analyzer
       | TaintedInput | Detected tainted html |
     And I see no other errors
 
+  Scenario: One tainted parameter (in a variable) of the twig template (named in a variable) is displayed with only the raw filter
+    Given I have the following code
+      """
+      $untrustedParameters = ['untrusted' => $_GET['untrusted']];
+      $template = 'index.html.twig';
+
+      twig()->render($template, $untrustedParameters);
+      """
+    And I have the following "index.html.twig" template
+      """
+      <h1>
+        {{ untrusted|raw }}
+      </h1>
+      """
+    When I run Psalm with taint analysis
+    Then I see these errors
+      | Type         | Message               |
+      | TaintedInput | Detected tainted html |
+    And I see no other errors
+
   Scenario: One tainted parameter of the twig rendering is displayed with some filter followed by the raw filter
     Given I have the following code
       """

--- a/tests/acceptance/acceptance/TwigTaintingWithCachedTemplates.feature
+++ b/tests/acceptance/acceptance/TwigTaintingWithCachedTemplates.feature
@@ -86,6 +86,27 @@ Feature: Twig tainting with cached templates
       | TaintedInput | Detected tainted html |
     And I see no other errors
 
+  Scenario: One tainted parameter (in a variable) of the twig template (named in a variable) is displayed with only the raw filter
+    Given I have the following code
+      """
+      $untrustedParameters = ['untrusted' => $_GET['untrusted']];
+      $template = 'index.html.twig';
+
+      twig()->render($template, $untrustedParameters);
+      """
+    And I have the following "index.html.twig" template
+      """
+      <h1>
+        {{ untrusted|raw }}
+      </h1>
+      """
+    And the "index.html.twig" template is compiled in the "cache/twig/" directory
+    When I run Psalm with taint analysis
+    Then I see these errors
+      | Type         | Message               |
+      | TaintedInput | Detected tainted html |
+    And I see no other errors
+
   Scenario: The template has a taint sink and is aliased
     Given I have the following code
       """

--- a/tests/unit/Symfony/TwigUtilsTest.php
+++ b/tests/unit/Symfony/TwigUtilsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\SymfonyPsalmPlugin\Tests\Symfony;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Psalm\Codebase;
+use Psalm\Config;
+use Psalm\Context;
+use Psalm\Internal\Analyzer\FileAnalyzer;
+use Psalm\Internal\Analyzer\ProjectAnalyzer;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Internal\Provider\FileProvider;
+use Psalm\Internal\Provider\NodeDataProvider;
+use Psalm\Internal\Provider\Providers;
+use Psalm\Internal\Provider\StatementsProvider;
+use Psalm\Plugin\Hook\AfterEveryFunctionCallAnalysisInterface;
+use Psalm\StatementsSource;
+use Psalm\Storage\FunctionStorage;
+use Psalm\SymfonyPsalmPlugin\Twig\TwigUtils;
+use RuntimeException;
+
+class TwigUtilsTest extends TestCase
+{
+    /**
+     * @dataProvider provideExpressions
+     */
+    public function testItCanExtractTheTemplateNameFromAnExpression(string $expression)
+    {
+        $code = '<?php'."\n".$expression;
+        $statements = StatementsProvider::parseStatements($code, '7.1');
+
+        $assertionHook = new class() implements AfterEveryFunctionCallAnalysisInterface {
+            public static function afterEveryFunctionCallAnalysis(FuncCall $expr, string $function_id, Context $context, StatementsSource $statements_source, Codebase $codebase): void
+            {
+                Assert::assertSame('expected.twig', TwigUtils::extractTemplateNameFromExpression($expr->args[0]->value, $statements_source));
+            }
+        };
+
+        $statementsAnalyzer = self::createStatementsAnalyzer($assertionHook);
+        $statementsAnalyzer->analyze($statements, new Context());
+    }
+
+    public function provideExpressions(): array
+    {
+        return [
+            ['dummy("expected.twig");'],
+            ['dummy(\'expected.twig\');'],
+            ['$a = "expected.twig"; dummy($a);'],
+        ];
+    }
+
+    public function testItThrowsAnExceptionWhenTryingToExtractTemplateNameFromAnUnsupportedExpression()
+    {
+        $code = '<?php'."\n".'dummy(123);';
+        $statements = StatementsProvider::parseStatements($code, '7.1');
+
+        $assertionHook = new class() implements AfterEveryFunctionCallAnalysisInterface {
+            public static function afterEveryFunctionCallAnalysis(FuncCall $expr, string $function_id, Context $context, StatementsSource $statements_source, Codebase $codebase): void
+            {
+                TwigUtils::extractTemplateNameFromExpression($expr->args[0]->value, $statements_source);
+            }
+        };
+
+        $statementsAnalyzer = self::createStatementsAnalyzer($assertionHook);
+
+        $this->expectException(RuntimeException::class);
+        $statementsAnalyzer->analyze($statements, new Context());
+    }
+
+    private static function createStatementsAnalyzer(AfterEveryFunctionCallAnalysisInterface $hook): StatementsAnalyzer
+    {
+        $config = (function () { return new self(); })->bindTo(null, Config::class)();
+        $config->after_every_function_checks[] = $hook;
+
+        $nullFileAnalyzer = new FileAnalyzer(new ProjectAnalyzer($config, new Providers(new FileProvider())), '', '');
+        $nullFileAnalyzer->codebase->functions->addGlobalFunction('dummy', new FunctionStorage());
+        $nullFileAnalyzer->codebase->file_storage_provider->create('');
+
+        $nodeData = new NodeDataProvider();
+        (function () use ($nodeData) {
+            $this->node_data = $nodeData;
+        })->bindTo($nullFileAnalyzer, $nullFileAnalyzer)();
+
+        return new StatementsAnalyzer($nullFileAnalyzer, $nodeData);
+    }
+}


### PR DESCRIPTION
Before this, taints were not forwarded if the call to `Twig\Environment::render` was made using variables as arguments (i.e. template name and template parameters).

In other words : 
```php
$untrusted = $_GET['untrusted'];

// this was the only supported syntax before
$twig->render('index.html.twig', ['untrusted' => $untrusted]);

// this is now supported
$template = 'index.html.twig';
$parameters = ['untrusted' => $untrusted];
$twig->render($template, $parameters);
```