### PR TITLE
Stub ParameterBag to provide taint information for Symfony 3/4/5.0

### DIFF
--- a/src/Stubs/5/InputBag.stubphp
+++ b/src/Stubs/5/InputBag.stubphp
@@ -10,6 +10,18 @@ final class InputBag extends ParameterBag
      * @template D of string|null
      * @psalm-param D $default
      * @psalm-return string|D
+     * @psalm-taint-source input
      */
     public function get(string $key, $default = null) {}
+
+    /**
+     * Returns the parameters.
+     *
+     * @param string|null $key The name of the parameter to return or null to get them all
+     *
+     * @return array An array of parameters
+     *
+     * @psalm-taint-source input
+     */
+    public function all(string $key = null) {}
 }

--- a/src/Stubs/common/ParameterBag.stubphp
+++ b/src/Stubs/common/ParameterBag.stubphp
@@ -2,15 +2,15 @@
 
 namespace Symfony\Component\HttpFoundation;
 
-final class InputBag extends ParameterBag
+class ParameterBag implements \IteratorAggregate, \Countable
 {
     /**
-     * Returns a string input value by name.
+     * Returns a parameter by name.
      *
-     * @param string|null $default The default value if the input key does not exist
+     * @param string $key     The key
+     * @param mixed  $default The default value if the parameter key does not exist
      *
-     * @return string|null
-     *
+     * @return mixed
      * @psalm-taint-source input
      */
     public function get(string $key, $default = null) {}

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -24,7 +24,6 @@ Feature: Tainting
       """
 
   Scenario Outline: One parameter of the Request's request/query/cookies is printed in the body of a Response object
-    Given I have the "symfony/framework-bundle" package satisfying the "^5.1"
     And I have the following code
       """
       class MyController
@@ -48,7 +47,6 @@ Feature: Tainting
       | ->cookies |
 
   Scenario Outline: All parameters of the Request's request/query/cookies are exported in the body of a Response object
-    Given I have the "symfony/framework-bundle" package satisfying the "^5.1"
     And I have the following code
       """
       class MyController


### PR DESCRIPTION
Currently the taint annotations are added to the `InputBag`, which means that they are only used with Symfony ^5.1.

This pull requests adds the annotations to the `ParameterBag` as well to enable the taint information for Symfony 3, 4 and 5.0. (The annotations for the `InputBag` in the stub for Symfony 5 had to be duplicated unfortunately, as the code would otherwise override the annotations from the `ParameterBag` again.)