### PR TITLE
Install the correct version of the symfony packages

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -93,6 +93,7 @@ jobs:
         with:
           coverage: none
           php-version: ${{ matrix.php-version }}
+          tools: flex
 
       - name: "Determine composer cache directory"
         id: determine-composer-cache-directory
@@ -105,17 +106,11 @@ jobs:
           key: php-${{ matrix.php-version }}-composer-${{ matrix.symfony-version }}-${{ hashFiles('composer.json') }}
           restore-keys: php-${{ matrix.php-version }}-composer-${{ matrix.symfony-version }}-
 
-      - name: "Install symfony 3 dependencies from composer.json"
-        if: matrix.symfony-version == '3'
-        run: composer require symfony/framework-bundle ^3.0 --prefer-stable --update-with-all-dependencies --no-interaction --no-progress --no-suggest
+      - name: "Restrict symfony dependencies to the correct version"
+        run: composer config extra.symfony.require ${{ matrix.symfony-version }}.*
 
-      - name: "Install Symfony 4 dependencies from composer.json"
-        if: matrix.symfony-version == '4'
-        run: composer require symfony/framework-bundle ^4.0 --prefer-stable --update-with-all-dependencies --no-interaction --no-progress --no-suggest
-
-      - name: "Install Symfony 5 dependencies from composer.json"
-        if: matrix.symfony-version == '5'
-        run: composer require symfony/framework-bundle ^5.0 --prefer-stable --update-with-all-dependencies --no-interaction --no-progress --no-suggest
+      - name: "Update dependencies with restricted symfony version"
+        run: composer update --prefer-stable --no-interaction --no-progress
 
       - name: "Run unit tests with phpunit"
         run: vendor/bin/phpunit --configuration=phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         }
     },
     "conflict": {
-        "vimeo/psalm": "~4.2.0"
+        "vimeo/psalm": "~4.2"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
In the Github workflow, the installed symfony package versions are not correct. For example, in the latest run with symfony 4 the following packages are installed:

```
  - Locking symfony/amqp-messenger (v5.2.0)
  - Locking symfony/cache (v5.2.0)
  - Locking symfony/cache-contracts (v2.2.0)
  - Locking symfony/config (v5.2.0)
  - Locking symfony/console (v4.4.17)
  - Locking symfony/css-selector (v5.2.0)
  - Locking symfony/debug (v4.4.17)
  - Locking symfony/dependency-injection (v5.2.0)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/doctrine-messenger (v5.2.0)
  - Locking symfony/error-handler (v4.4.17)
  - Locking symfony/event-dispatcher (v4.4.17)
  - Locking symfony/event-dispatcher-contracts (v1.1.9)
  - Locking symfony/filesystem (v5.2.0)
  - Locking symfony/finder (v5.2.0)
  - Locking symfony/framework-bundle (v4.4.17)
  - Locking symfony/http-client-contracts (v2.3.1)
  - Locking symfony/http-foundation (v5.2.0)
  - Locking symfony/http-kernel (v4.4.17)
  - Locking symfony/messenger (v5.2.0)
  - Locking symfony/polyfill-ctype (v1.20.0)
  - Locking symfony/polyfill-intl-grapheme (v1.20.0)
  - Locking symfony/polyfill-intl-normalizer (v1.20.0)
  - Locking symfony/polyfill-mbstring (v1.20.0)
  - Locking symfony/polyfill-php73 (v1.20.0)
  - Locking symfony/polyfill-php80 (v1.20.0)
  - Locking symfony/property-access (v5.2.0)
  - Locking symfony/property-info (v5.2.0)
  - Locking symfony/redis-messenger (v5.2.0)
  - Locking symfony/routing (v5.2.0)
  - Locking symfony/security-core (v5.2.0)
  - Locking symfony/security-guard (v5.2.0)
  - Locking symfony/security-http (v5.1.9)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking symfony/string (v5.2.0)
  - Locking symfony/translation-contracts (v2.3.0)
  - Locking symfony/validator (v5.2.0)
  - Locking symfony/var-dumper (v5.2.0)
  - Locking symfony/var-exporter (v5.2.0)
  - Locking symfony/yaml (v5.2.0)
```

This pull request adds `symfony/flex`, to correctly restrict the installed package versions. This will also enable #103 