### PR TITLE
Allow Psalm 4.2 and later

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,6 @@
             "Psalm\\SymfonyPsalmPlugin\\Tests\\": ["tests/unit"]
         }
     },
-    "conflict": {
-        "vimeo/psalm": "~4.2"
-    },
     "config": {
         "sort-packages": true
     },

--- a/src/Handler/ContainerHandler.php
+++ b/src/Handler/ContainerHandler.php
@@ -87,7 +87,7 @@ class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterClassLi
         }
 
         if ($expr->args[0]->value instanceof String_) {
-            $serviceId = (string) $expr->args[0]->value->value;
+            $serviceId = $expr->args[0]->value->value;
         } elseif ($expr->args[0]->value instanceof ClassConstFetch) {
             $serviceId = (string) $expr->args[0]->value->class->getAttribute('resolvedName');
         } else {

--- a/src/Symfony/ContainerMeta.php
+++ b/src/Symfony/ContainerMeta.php
@@ -55,7 +55,7 @@ class ContainerMeta
     {
         /** @var string $containerXmlPath */
         foreach ($containerXmlPaths as $containerXmlPath) {
-            $xmlPath = realpath((string) $containerXmlPath);
+            $xmlPath = realpath($containerXmlPath);
             if (!$xmlPath || !file_exists($xmlPath)) {
                 continue;
             }

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -37,7 +37,7 @@ Feature: Tainting
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
     Examples:
       | property  |
@@ -60,7 +60,7 @@ Feature: Tainting
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
     Examples:
       | property |
@@ -82,7 +82,7 @@ Feature: Tainting
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
 
   Scenario: All headers are printed in the body of a Response object
@@ -99,5 +99,5 @@ Feature: Tainting
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors

--- a/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature
+++ b/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature
@@ -80,7 +80,7 @@ Feature: Twig tainting with analyzer
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
 
   Scenario: One tainted parameter (in a variable) of the twig template (named in a variable) is displayed with only the raw filter
@@ -100,7 +100,7 @@ Feature: Twig tainting with analyzer
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
 
   Scenario: One tainted parameter of the twig rendering is displayed with some filter followed by the raw filter
@@ -118,7 +118,7 @@ Feature: Twig tainting with analyzer
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
 
   Scenario: One tainted parameter of the twig rendering is displayed with the raw filter followed by some other filter
@@ -160,7 +160,7 @@ Feature: Twig tainting with analyzer
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
 
   Scenario: One tainted parameter of the twig template is displayed with autoescaping deactivated
@@ -180,7 +180,7 @@ Feature: Twig tainting with analyzer
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
 
   Scenario: One tainted parameter of the twig template is assigned to a variable and this variable is displayed
@@ -200,5 +200,5 @@ Feature: Twig tainting with analyzer
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors

--- a/tests/acceptance/acceptance/TwigTaintingWithCachedTemplates.feature
+++ b/tests/acceptance/acceptance/TwigTaintingWithCachedTemplates.feature
@@ -83,7 +83,7 @@ Feature: Twig tainting with cached templates
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
 
   Scenario: One tainted parameter (in a variable) of the twig template (named in a variable) is displayed with only the raw filter
@@ -104,7 +104,7 @@ Feature: Twig tainting with cached templates
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
 
   Scenario: The template has a taint sink and is aliased
@@ -124,7 +124,7 @@ Feature: Twig tainting with cached templates
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
 
   Scenario: The template has a taint sink and is aliased using the old notation
@@ -144,7 +144,7 @@ Feature: Twig tainting with cached templates
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
 
   Scenario: The template has a taint sink and is rendered using the old alias notation
@@ -164,5 +164,5 @@ Feature: Twig tainting with cached templates
     When I run Psalm with taint analysis
     Then I see these errors
       | Type         | Message               |
-      | TaintedInput | Detected tainted html |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors


### PR DESCRIPTION
Psalm 4.2 added new issue types for the tainted input and thus broke the current tests. This pull requests reverts #104 and adds support for Psalm ^4.2.