### PR TITLE
Added mixed type to serializer $data parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/console": "*",
         "symfony/messenger": "^4.2 || ^5.0",
         "symfony/security-guard": "^4.0 || ^5.0",
+        "symfony/serializer": "^4.0 || ^5.0",
         "symfony/validator": "*",
         "twig/twig": "^2.10 || ^3.0",
         "weirdan/codeception-psalm-module": "~0.9"

--- a/src/Stubs/common/DenormalizerInterface.stubphp
+++ b/src/Stubs/common/DenormalizerInterface.stubphp
@@ -7,6 +7,7 @@ interface DenormalizerInterface
     /**
      * @template TObject of object
      * @template TType of string|class-string<TObject>
+     * @psalm-param mixed $data
      * @psalm-param TType $type
      * @psalm-return (TType is class-string<TObject> ? TObject : mixed)
      */

--- a/src/Stubs/common/SerializerInterface.stubphp
+++ b/src/Stubs/common/SerializerInterface.stubphp
@@ -7,6 +7,7 @@ interface SerializerInterface
     /**
      * @template TObject of object
      * @template TType of string|class-string<TObject>
+     * @psalm-param mixed $data
      * @psalm-param TType $type
      * @psalm-return (TType is class-string<TObject> ? TObject : mixed)
      */

--- a/tests/acceptance/acceptance/DenormalizerInterface.feature
+++ b/tests/acceptance/acceptance/DenormalizerInterface.feature
@@ -22,7 +22,9 @@ Feature: Denormalizer interface
     Given I have the following code
       """
       <?php
-      function test(\Symfony\Component\Serializer\Normalizer\DenormalizerInterface $denormalizer): void
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      function test(DenormalizerInterface $denormalizer): void
       {
         $result = $denormalizer->denormalize([], stdClass::class);
         /** @psalm-trace $result */
@@ -38,7 +40,9 @@ Feature: Denormalizer interface
     Given I have the following code
       """
       <?php
-      function test(\Symfony\Component\Serializer\Normalizer\DenormalizerInterface $denormalizer): void
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      function test(DenormalizerInterface $denormalizer): void
       {
         $result = $denormalizer->denormalize([], 'stdClass[]');
         /** @psalm-trace $result */
@@ -50,3 +54,25 @@ Feature: Denormalizer interface
       | MixedAssignment        | Unable to determine the type that $result is being assigned to |
       | Trace                  | $result: mixed                                                 |
     And I see no other errors
+
+  Scenario: Psalm does not complain about the missing $data parameter type in the denormalizer implementation
+    Given I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      final class Denormalizer implements DenormalizerInterface
+      {
+        public function supportsDenormalization($data, string $type, string $format = null)
+        {
+          return true;
+        }
+
+        public function denormalize($data, string $type, string $format = null, array $context = [])
+        {
+          return null;
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/acceptance/SerializerInterface.feature
+++ b/tests/acceptance/acceptance/SerializerInterface.feature
@@ -22,7 +22,9 @@ Feature: Serializer interface
     Given I have the following code
       """
       <?php
-      function test(\Symfony\Component\Serializer\SerializerInterface $serializer): void
+      use Symfony\Component\Serializer\SerializerInterface;
+
+      function test(SerializerInterface $serializer): void
       {
         $result = $serializer->deserialize([], stdClass::class, 'json');
         /** @psalm-trace $result */
@@ -38,7 +40,9 @@ Feature: Serializer interface
     Given I have the following code
       """
       <?php
-      function test(\Symfony\Component\Serializer\SerializerInterface $serializer): void
+      use Symfony\Component\Serializer\SerializerInterface;
+
+      function test(SerializerInterface $serializer): void
       {
         $result = $serializer->deserialize([], 'stdClass[]', 'json');
         /** @psalm-trace $result */
@@ -50,3 +54,25 @@ Feature: Serializer interface
       | MixedAssignment        | Unable to determine the type that $result is being assigned to |
       | Trace                  | $result: mixed                                                 |
     And I see no other errors
+
+  Scenario: Psalm does not complain about the missing $data parameter type in the serializer implementation
+    Given I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\SerializerInterface;
+
+      final class Serializer implements SerializerInterface
+      {
+        public function serialize($data, string $format, array $context = [])
+        {
+          return '';
+        }
+
+        public function deserialize($data, string $type, string $format, array $context = [])
+        {
+          return [];
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
Otherwise Psalm said `MissingParamType: Parameter $data has no provided type`. The `symfony/serializer` package is required to check that in tests.