### PR TITLE
Twig print should not be an actual taint sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ To leverage the real Twig file analyzer, you have to configure a checker for the
 </fileExtensions>
 ```
 
+[See the currently supported cases.](https://github.com/psalm/psalm-plugin-symfony/blob/master/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature)
+
 #### Cache Analyzer
 
 This approach is "dirtier", since it tries to connect the taints from the application code to the compiled PHP code representing a given template.
@@ -104,6 +106,8 @@ To allow the analysis through the cached template files, you have to add the `tw
     <twigCachePath>/cache/twig</twigCachePath>
 </pluginClass>
 ```
+
+[See the currently supported cases.](https://github.com/psalm/psalm-plugin-symfony/blob/master/tests/acceptance/acceptance/TwigTaintingWithCachedTemplates.feature)
 
 ### Credits
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1 || ^8.0",
         "ext-simplexml": "*",
         "symfony/framework-bundle": "^3.0 || ^4.0 || ^5.0",
-        "vimeo/psalm": "^4.1 <4.3.2"
+        "vimeo/psalm": "^4.3.2"
     },
     "require-dev": {
         "doctrine/orm": "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1 || ^8.0",
         "ext-simplexml": "*",
         "symfony/framework-bundle": "^3.0 || ^4.0 || ^5.0",
-        "vimeo/psalm": "^4.3.2"
+        "vimeo/psalm": "^4.4.1"
     },
     "require-dev": {
         "doctrine/orm": "^2.7",

--- a/src/Stubs/5/Request.stubphp
+++ b/src/Stubs/5/Request.stubphp
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+class Request
+{
+    /**
+     * @psalm-var InputBag
+     */
+    public $request;
+}

--- a/src/Twig/TemplateFileAnalyzer.php
+++ b/src/Twig/TemplateFileAnalyzer.php
@@ -20,7 +20,6 @@ class TemplateFileAnalyzer extends FileAnalyzer
 {
     public function analyze(
         PsalmContext $file_context = null,
-        bool $preserve_analyzers = false,
         PsalmContext $global_context = null
     ): void {
         $codebase = $this->project_analyzer->getCodebase();

--- a/src/Twig/TemplateFileAnalyzer.php
+++ b/src/Twig/TemplateFileAnalyzer.php
@@ -52,6 +52,7 @@ class TemplateFileAnalyzer extends FileAnalyzer
         $traverser->traverse($tree);
 
         $twigContext->taintUnassignedVariables($local_file_name);
+        $twigContext->taintSinks($local_file_name);
     }
 
     public static function getTaintNodeForTwigNamedVariable(

--- a/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature
+++ b/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature
@@ -54,7 +54,7 @@ Feature: Twig tainting with analyzer
     Given I have the following code
       """
       $untrusted = $_GET['untrusted'];
-      twig()->render('index.html.twig', ['untrusted' => $untrusted]);
+      echo twig()->render('index.html.twig', ['untrusted' => $untrusted]);
       """
     And I have the following "index.html.twig" template
       """
@@ -65,11 +65,26 @@ Feature: Twig tainting with analyzer
     When I run Psalm with taint analysis
     And I see no errors
 
-  Scenario: One tainted parameter of the twig template is displayed with only the raw filter
+  Scenario: One tainted parameter of the twig template is rendered with only the raw filter but the not displayed
     Given I have the following code
       """
       $untrusted = $_GET['untrusted'];
       twig()->render('index.html.twig', ['untrusted' => $untrusted]);
+      """
+    And I have the following "index.html.twig" template
+      """
+      <h1>
+        {{ untrusted|raw }}
+      </h1>
+      """
+    When I run Psalm with taint analysis
+    And I see no errors
+
+  Scenario: One tainted parameter of the twig template is displayed with only the raw filter
+    Given I have the following code
+      """
+      $untrusted = $_GET['untrusted'];
+      echo twig()->render('index.html.twig', ['untrusted' => $untrusted]);
       """
     And I have the following "index.html.twig" template
       """
@@ -89,7 +104,7 @@ Feature: Twig tainting with analyzer
       $untrustedParameters = ['untrusted' => $_GET['untrusted']];
       $template = 'index.html.twig';
 
-      twig()->render($template, $untrustedParameters);
+      echo twig()->render($template, $untrustedParameters);
       """
     And I have the following "index.html.twig" template
       """
@@ -107,7 +122,7 @@ Feature: Twig tainting with analyzer
     Given I have the following code
       """
       $untrusted = $_GET['untrusted'];
-      twig()->render('index.html.twig', ['untrusted' => $untrusted]);
+      echo twig()->render('index.html.twig', ['untrusted' => $untrusted]);
       """
     And I have the following "index.html.twig" template
       """
@@ -125,7 +140,7 @@ Feature: Twig tainting with analyzer
     Given I have the following code
       """
       $untrusted = $_GET['untrusted'];
-      twig()->render('index.html.twig', ['untrusted' => $untrusted]);
+      echo twig()->render('index.html.twig', ['untrusted' => $untrusted]);
       """
     And I have the following "index.html.twig" template
       """
@@ -140,7 +155,7 @@ Feature: Twig tainting with analyzer
     Given I have the following code
       """
       $untrusted = $_GET['untrusted'];
-      twig()->render('index.html.twig', ['untrusted' => $untrusted]);
+      echo twig()->render('index.html.twig', ['untrusted' => $untrusted]);
       """
     And I have the following "base.html.twig" template
       """
@@ -167,7 +182,7 @@ Feature: Twig tainting with analyzer
     Given I have the following code
       """
       $untrusted = $_GET['untrusted'];
-      twig()->render('index.html.twig', ['untrusted' => $untrusted]);
+      echo twig()->render('index.html.twig', ['untrusted' => $untrusted]);
       """
     And I have the following "index.html.twig" template
       """
@@ -187,7 +202,7 @@ Feature: Twig tainting with analyzer
     Given I have the following code
       """
       $untrusted = $_GET['untrusted'];
-      twig()->render('index.html.twig', ['untrusted' => $untrusted]);
+      echo twig()->render('index.html.twig', ['untrusted' => $untrusted]);
       """
     And I have the following "index.html.twig" template
       """


### PR DESCRIPTION
Before, an issue would have been raised with this code :

```php
$untrusted = $_GET['untrusted'];
twig()->render('index.html.twig', ['untrusted' => $untrusted]); // this does not actually display anything 
```

After, the taint actually goes out of the call, and only the following code would raise the issue  : 

```php
$untrusted = $_GET['untrusted'];
echo twig()->render('index.html.twig', ['untrusted' => $untrusted]); // the taint goes to an actual sink
```

NB : this only concerns the twig template parsing approach; as the second approach uses the cached templates which contains actual `echo`s, they are themselves considered taint sinks and we can not do nothing about it for the moment.