### PR TITLE
[security] voter - suppress MoreSpecificImplementedParamType on voteOnAttribute

### DIFF
--- a/src/Stubs/common/Voter.stubphp
+++ b/src/Stubs/common/Voter.stubphp
@@ -1,0 +1,42 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+abstract class Voter implements VoterInterface
+{
+    /**
+     * Returns the vote for the given parameters.
+     *
+     * This method must return one of the following constants:
+     * ACCESS_GRANTED, ACCESS_DENIED, or ACCESS_ABSTAIN.
+     *
+     * @param mixed $subject    The subject to secure
+     * @param array $attributes An array of attributes associated with the method being invoked
+     *
+     * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
+     */
+    public function vote(TokenInterface $token, $subject, array $attributes) {}
+
+    /**
+     * Determines if the attribute and subject are supported by this voter.
+     *
+     * @param string $attribute An attribute
+     * @param mixed  $subject   The subject to secure, e.g. an object the user wants to access or any other PHP type
+     *
+     * @return bool True if the attribute and subject are supported, false otherwise
+     */
+    abstract protected function supports(string $attribute, $subject);
+
+    /**
+     * Perform a single access check operation on a given attribute, subject and token.
+     * It is safe to assume that $attribute and $subject already passed the "supports()" method check.
+     *
+     * @psalm-suppress MoreSpecificImplementedParamType
+     * @param mixed $subject
+     *
+     * @return bool
+     */
+    abstract protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token);
+}

--- a/tests/acceptance/acceptance/Voter.feature
+++ b/tests/acceptance/acceptance/Voter.feature
@@ -1,0 +1,53 @@
+@symfony-common
+Feature: Voter abstract class
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm errorLevel="1">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+
+        <plugins>
+          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
+      """
+      <?php
+
+      use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+      use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+      class VoterSubject {}
+      """
+
+  Scenario: Assert MoreSpecificImplementedParamType is not raised on voteOnAttribute
+    Given I have the following code
+      """
+      class SomeVoter extends Voter
+      {
+          protected function supports(string $attribute, $subject): bool
+          {
+              return $subject instanceof VoterSubject;
+          }
+
+          /**
+           * @param VoterSubject $subject
+           */
+          protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+          {
+              /** @psalm-trace $subject */
+              return true;
+          }
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type  | Message                |
+      | Trace | $subject: VoterSubject |
+    And I see no other errors


### PR DESCRIPTION
partially resolves https://github.com/psalm/psalm-plugin-symfony/issues/107