### PR TITLE
Add stubs with templates for `AbstractController::createForm()`

### DIFF
--- a/src/Stubs/4/AbstractController.stubphp
+++ b/src/Stubs/4/AbstractController.stubphp
@@ -12,4 +12,14 @@ class AbstractController implements ServiceSubscriberInterface
      * @psalm-suppress PropertyNotSetInConstructor
      */
     protected $container;
+
+    /**
+     * @template TData
+     * @template TFormType of FormTypeInterface<TData>
+     *
+     * @psalm-param class-string<TFormType> $type
+     *
+     * @psalm-return FormInterface<TData>
+     */
+    public function createForm(string $type, $data = null, array $options = []): FormInterface {}
 }

--- a/src/Stubs/5/AbstractController.stubphp
+++ b/src/Stubs/5/AbstractController.stubphp
@@ -12,4 +12,14 @@ class AbstractController implements ServiceSubscriberInterface
      * @psalm-suppress PropertyNotSetInConstructor
      */
     protected $container;
+
+    /**
+     * @template TData
+     * @template TFormType of FormTypeInterface<TData>
+     *
+     * @psalm-param class-string<TFormType> $type
+     *
+     * @psalm-return FormInterface<TData>
+     */
+    public function createForm(string $type, $data = null, array $options = []): FormInterface {}
 }


### PR DESCRIPTION
These stubs allows to help user know, what data will be returned after calling `$form->getData()` in the controller.

How it should works: 
```php
/** @implements FormTypeInterface<User> */
class UserType implements FormTypeInterface {}

class User {
	public function getName(): string { return 'name'; }
}

$userForm = createForm(UserType::class);

/** @psalm-trace $user */
$user = $userForm->getData(); // INFO: Trace - 35:1 - $user: User
```
https://psalm.dev/r/ef9c7074e1

ToDo: 
- [ ] tests

discussion ref: #155
//cc @zmitic 