### PR TITLE
Fix children typehint

### DIFF
--- a/src/Stubs/common/forms/FormView.stubphp
+++ b/src/Stubs/common/forms/FormView.stubphp
@@ -26,7 +26,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     public $parent;
 
     /**
-     * @psalm-var list<FormView>
+     * @psalm-var array<string, FormView>
      */
     public $children = [];
 }


### PR DESCRIPTION
Another bugfix for Formview.

Since, the method `has` or `get` expects a string, the key of the array `children` should be string too.

cc @seferov @zmitic 