### PR TITLE
Add Constraint stub

### DIFF
--- a/src/Stubs/common/Constraint.stubphp
+++ b/src/Stubs/common/Constraint.stubphp
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Validator;
+
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+abstract class Constraint
+{
+    /**
+     * @var array<string, string>
+     */
+    protected static $errorNames = [];
+}


### PR DESCRIPTION
Prevents this error:

```
ERROR: NonInvariantDocblockPropertyType
at /app/src/Library/Symfony/Constraint/MyConstraint.php:26:19
Property App\Library\Symfony\Constraint\MyConstraint::$errorNames has type array<string, string>, not invariant with Symfony\Component\Validator\Constraint::$errorNames of type mixed (see https://psalm.dev/267)
        protected static $errorNames = [
```