### PR TITLE
Add Constraint stub

### DIFF
--- a/src/Stubs/common/Constraint.stubphp
+++ b/src/Stubs/common/Constraint.stubphp
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Validator;
+
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+abstract class Constraint
+{
+    /**
+     * @var array<string, string>
+     */
+    protected static $errorNames = [];
+}

--- a/tests/acceptance/acceptance/Constraint.feature
+++ b/tests/acceptance/acceptance/Constraint.feature
@@ -1,0 +1,37 @@
+@symfony-common
+Feature: Constraint
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm errorLevel="1">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+
+  Scenario: NonInvariantDocblockPropertyType error about $errorNames is not raised
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Component\Validator\Constraint;
+
+      class CustomConstraint extends Constraint
+      {
+        /**
+         * @var array<string, string>
+         */
+        protected static $errorNames = [
+          'test' => 'test',
+        ];
+      }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
GitHub doesn't let me reopen #165 so I have to create a new PR.

I has a problem reproducing the bug because the NonInvariantDocblockPropertyType issue is suppressed if the Constraint class is stubbed. So when I just removed the `@var array<string, string>` annotation the test didn't fail as I expected. However when I remove the stub file, the test does indeed fail.