### PR TITLE
[Refactoring] Get rid of most of the boilerplate psalm config in tests

### DIFF
--- a/tests/acceptance/acceptance.suite.yml
+++ b/tests/acceptance/acceptance.suite.yml
@@ -4,5 +4,5 @@ modules:
   enabled:
     - Cli
     - Filesystem
-    - \Weirdan\Codeception\Psalm\Module
+    - Weirdan\Codeception\Psalm\Module
     - \Psalm\SymfonyPsalmPlugin\Test\CodeceptionModule

--- a/tests/acceptance/acceptance/AbstractController.feature
+++ b/tests/acceptance/acceptance/AbstractController.feature
@@ -2,22 +2,7 @@
 Feature: AbstractController
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: PropertyNotSetInConstructor error about $container is not raised
     Given I have the following code

--- a/tests/acceptance/acceptance/Annotation.feature
+++ b/tests/acceptance/acceptance/Annotation.feature
@@ -2,24 +2,9 @@
 Feature: Annotation class
 
   Background:
-    Given I have the following config
+    Given I have Symfony plugin enabled with the following config
       """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin">
-            <containerXml>../../tests/acceptance/container.xml</containerXml>
-          </pluginClass>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
+      <containerXml>../../tests/acceptance/container.xml</containerXml>
       """
 
   Scenario: PropertyNotSetInConstructor error is not raised when class is an Annotation class.

--- a/tests/acceptance/acceptance/AuthenticatorInterface.feature
+++ b/tests/acceptance/acceptance/AuthenticatorInterface.feature
@@ -2,23 +2,7 @@
 Feature: AuthenticatorInterface
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: Authenticator correctly resolves $credentials and $user types
     Given I have the following code

--- a/tests/acceptance/acceptance/CacheInterface.feature
+++ b/tests/acceptance/acceptance/CacheInterface.feature
@@ -2,23 +2,8 @@
 Feature: CacheInterface
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedClosureParam errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have issue handler "UnusedClosureParam" suppressed
+    And I have Symfony plugin enabled
 
   Scenario: CacheInterface::get has the same return type as the passed callback
     Given I have the following code

--- a/tests/acceptance/acceptance/Configuration.feature
+++ b/tests/acceptance/acceptance/Configuration.feature
@@ -2,20 +2,7 @@
 Feature: Configuration
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: ArrayNodeDefinition correctly resolves prototype($foo) return type
     Given I have the following code
@@ -49,8 +36,6 @@ Feature: Configuration
     Then I see these errors
       | Type  | Message                                                                              |
       | Trace          | $arrayNode: Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition |
-      | UnusedVariable | $arrayNode is never referenced or the value is not used                     |
       | Trace          | $enumNode: Symfony\Component\Config\Definition\Builder\EnumNodeDefinition   |
-      | UnusedVariable | $enumNode is never referenced or the value is not used                      |
 
     And I see no other errors

--- a/tests/acceptance/acceptance/ConsoleArgument.feature
+++ b/tests/acceptance/acceptance/ConsoleArgument.feature
@@ -2,22 +2,7 @@
 Feature: ConsoleArgument
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/ConsoleOption.feature
+++ b/tests/acceptance/acceptance/ConsoleOption.feature
@@ -2,23 +2,8 @@
 Feature: ConsoleOption
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedParam errorLevel="info"/>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have issue handlers "UnusedParam,UnusedVariable" suppressed
+    And I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/Constraint.feature
+++ b/tests/acceptance/acceptance/Constraint.feature
@@ -2,19 +2,7 @@
 Feature: Constraint
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: NonInvariantDocblockPropertyType error about $errorNames is not raised
     Given I have the following code

--- a/tests/acceptance/acceptance/ConstraintValidator.feature
+++ b/tests/acceptance/acceptance/ConstraintValidator.feature
@@ -2,22 +2,7 @@
 Feature: ConstraintValidator
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: PropertyNotSetInConstructor error about $context is not raised
     Given I have the following code

--- a/tests/acceptance/acceptance/ContainerDependency.feature
+++ b/tests/acceptance/acceptance/ContainerDependency.feature
@@ -5,22 +5,7 @@ Feature: ContainerDependency
   I need Psalm to check container is not injected as a dependency
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: Asserting container dependency raises issue
     Given I have the following code

--- a/tests/acceptance/acceptance/ContainerService.feature
+++ b/tests/acceptance/acceptance/ContainerService.feature
@@ -3,23 +3,7 @@ Feature: Container service
   Detect ContainerInterface::get() result type
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: Asserting psalm recognizes return type of service got via 'ContainerInterface::get()'
     Given I have the following code

--- a/tests/acceptance/acceptance/ContainerXml.feature
+++ b/tests/acceptance/acceptance/ContainerXml.feature
@@ -3,24 +3,9 @@ Feature: Container XML config
   Detect ContainerInterface::get() result type
 
   Background:
-    Given I have the following config
+    Given I have Symfony plugin enabled with the following config
       """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin">
-            <containerXml>../../tests/acceptance/container.xml</containerXml>
-          </pluginClass>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
+      <containerXml>../../tests/acceptance/container.xml</containerXml>
       """
 
   Scenario: Asserting psalm recognizes return type of service got via 'ContainerInterface::get() using service ID'

--- a/tests/acceptance/acceptance/DenormalizerInterface.feature
+++ b/tests/acceptance/acceptance/DenormalizerInterface.feature
@@ -3,23 +3,7 @@ Feature: Denormalizer interface
   Detect DenormalizerInterface::denormalize() result type
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: Psalm recognizes denormalization result as an object when a class is passed as a type
     Given I have the following code

--- a/tests/acceptance/acceptance/DoctrineQueryBuilder.feature
+++ b/tests/acceptance/acceptance/DoctrineQueryBuilder.feature
@@ -2,23 +2,7 @@
 Feature: Doctrine QueryBuilder
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm>
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/Envelope.feature
+++ b/tests/acceptance/acceptance/Envelope.feature
@@ -2,23 +2,7 @@
 Feature: Messenger Envelope
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/HeaderBag.feature
+++ b/tests/acceptance/acceptance/HeaderBag.feature
@@ -2,23 +2,8 @@
 Feature: Header get
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedFunctionCall errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have issue handler "UnusedFunctionCall" suppressed
+    And I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/InputBag.feature
+++ b/tests/acceptance/acceptance/InputBag.feature
@@ -2,23 +2,8 @@
 Feature: InputBag get return type
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedFunctionCall errorLevel="info"/>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have issue handler "UnusedFunctionCall,UnusedVariable" suppressed
+    And I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/LockableTrait.feature
+++ b/tests/acceptance/acceptance/LockableTrait.feature
@@ -2,22 +2,7 @@
 Feature: LockableTrait
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: PropertyNotSetInConstructor error about $lock is not raised
     Given I have the following code

--- a/tests/acceptance/acceptance/NamingConventions.feature
+++ b/tests/acceptance/acceptance/NamingConventions.feature
@@ -3,24 +3,9 @@ Feature: Naming conventions
   Detect naming convention violations
 
   Background:
-    Given I have the following config
+    Given I have Symfony plugin enabled with the following config
       """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin">
-            <containerXml>../../tests/acceptance/container.xml</containerXml>
-          </pluginClass>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
+      <containerXml>../../tests/acceptance/container.xml</containerXml>
       """
 
   Scenario: There is no service naming convention violation, so no complaint.

--- a/tests/acceptance/acceptance/PropertyAccessorInterface.feature
+++ b/tests/acceptance/acceptance/PropertyAccessorInterface.feature
@@ -2,23 +2,8 @@
 Feature: PropertyAccessorInterface
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-          <UnusedFunctionCall errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have issue handlers "UnusedVariable,UnusedFunctionCall" suppressed
+    And I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/PropertyPathInterface.feature
+++ b/tests/acceptance/acceptance/PropertyPathInterface.feature
@@ -2,24 +2,8 @@
 Feature: PropertyPathInterface
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedParam errorLevel="info"/>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have issue handlers "UnusedParam,UnusedVariable" suppressed
+    And I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/RepositoryStringShortcut.feature
+++ b/tests/acceptance/acceptance/RepositoryStringShortcut.feature
@@ -5,24 +5,8 @@ Feature: RepositoryStringShortcut
   I need Psalm to check preferred repository syntax
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-          <UndefinedClass errorLevel="info" />
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have issue handlers "UndefinedClass,UnusedVariable" suppressed
+    And I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/RequestContent.feature
+++ b/tests/acceptance/acceptance/RequestContent.feature
@@ -3,23 +3,8 @@ Feature: Request getContent
   Symfony Request has getContent method on which return type changes based on argument
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedFunctionCall errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have issue handler "UnusedFunctionCall" suppressed
+    And I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/RequiredSetter.feature
+++ b/tests/acceptance/acceptance/RequiredSetter.feature
@@ -2,24 +2,9 @@
 Feature: Annotation class
 
   Background:
-    Given I have the following config
+    Given I have Symfony plugin enabled with the following config
       """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin">
-            <containerXml>../../tests/acceptance/container.xml</containerXml>
-          </pluginClass>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
+      <containerXml>../../tests/acceptance/container.xml</containerXml>
       """
 
   Scenario: PropertyNotSetInConstructor error is not raised when the @required annotation is present.

--- a/tests/acceptance/acceptance/RouteCollection.feature
+++ b/tests/acceptance/acceptance/RouteCollection.feature
@@ -2,23 +2,7 @@
 Feature: RouteCollection
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/SerializerInterface.feature
+++ b/tests/acceptance/acceptance/SerializerInterface.feature
@@ -3,23 +3,7 @@ Feature: Serializer interface
   Detect SerializerInterface::deserialize() result type
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: Psalm recognizes deserialization result as an object when a class is passed as a type
     Given I have the following code

--- a/tests/acceptance/acceptance/ServiceSubscriber.feature
+++ b/tests/acceptance/acceptance/ServiceSubscriber.feature
@@ -2,24 +2,9 @@
 Feature: Service Subscriber
 
   Background:
-    Given I have the following config
+    Given I have Symfony plugin enabled with the following config
       """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin">
-            <containerXml>../../tests/acceptance/container.xml</containerXml>
-          </pluginClass>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
+      <containerXml>../../tests/acceptance/container.xml</containerXml>
       """
 
   Scenario: Asserting psalm recognizes return type of services defined in getSubscribedServices

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -2,22 +2,7 @@
 Feature: Tainting
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/TestContainerService.feature
+++ b/tests/acceptance/acceptance/TestContainerService.feature
@@ -2,25 +2,10 @@
 Feature: Test Container service
 
   Background:
-    Given I have the following config
+    Given I have issue handlers "PropertyNotSetInConstructor,UnusedFunctionCall,UnusedVariable" suppressed
+    And I have Symfony plugin enabled with the following config
       """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin">
-            <containerXml>../../tests/acceptance/container.xml</containerXml>
-          </pluginClass>
-        </plugins>
-        <issueHandlers>
-          <PropertyNotSetInConstructor errorLevel="info" />
-          <UnusedFunctionCall errorLevel="info"/>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
+      <containerXml>../../tests/acceptance/container.xml</containerXml>
       """
 
   Scenario: KernelTestCase container can access private services

--- a/tests/acceptance/acceptance/TwigEnvironment.feature
+++ b/tests/acceptance/acceptance/TwigEnvironment.feature
@@ -2,20 +2,7 @@
 Feature: Twig Environment
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
 
   Scenario: getRuntime method return type is dynamic
     Given I have the following code

--- a/tests/acceptance/acceptance/Voter.feature
+++ b/tests/acceptance/acceptance/Voter.feature
@@ -2,23 +2,7 @@
 Feature: Voter abstract class
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
     And I have the following code preamble
       """
       <?php

--- a/tests/acceptance/acceptance/forms/AbstractType.feature
+++ b/tests/acceptance/acceptance/forms/AbstractType.feature
@@ -2,23 +2,7 @@
 Feature: FormType templates
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
   Scenario: Assert FormType is using nullable template value in methods
     Given I have the following code
           """

--- a/tests/acceptance/acceptance/forms/AbstractTypeExtension.feature
+++ b/tests/acceptance/acceptance/forms/AbstractTypeExtension.feature
@@ -2,23 +2,7 @@
 Feature: FormType templates
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
   Scenario: FormExtension::getExtendedTypes must return iterables of FormTypeInterface
     Given I have the following code
           """

--- a/tests/acceptance/acceptance/forms/Form.feature
+++ b/tests/acceptance/acceptance/forms/Form.feature
@@ -2,23 +2,7 @@
 Feature: Form test
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
   Scenario: Assert that Form::getData() will return nullable type (empty_data failure)
     Given I have the following code
           """

--- a/tests/acceptance/acceptance/forms/FormBuilterInterface.feature
+++ b/tests/acceptance/acceptance/forms/FormBuilterInterface.feature
@@ -2,23 +2,7 @@
 Feature: Form builder
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
   Scenario: Depending of typehinted form event, psalm will know type of data attached
     Given I have the following code
           """

--- a/tests/acceptance/acceptance/forms/FormConfigBuilterInterface.feature
+++ b/tests/acceptance/acceptance/forms/FormConfigBuilterInterface.feature
@@ -2,23 +2,7 @@
 Feature: Form config builder
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
   Scenario: Depending of typehinted form event, psalm will know type of data attached
     Given I have the following code
           """

--- a/tests/acceptance/acceptance/forms/FormConfigInterface.feature
+++ b/tests/acceptance/acceptance/forms/FormConfigInterface.feature
@@ -2,23 +2,7 @@
 Feature: Form config
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
   Scenario: FormConfigInterface::getData() will return ?T
     Given I have the following code
           """

--- a/tests/acceptance/acceptance/forms/FormFactoryInterface.feature
+++ b/tests/acceptance/acceptance/forms/FormFactoryInterface.feature
@@ -2,23 +2,7 @@
 Feature: Form factory
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
   Scenario: Test factory methods
     Given I have the following code
           """

--- a/tests/acceptance/acceptance/forms/FormInterface.feature
+++ b/tests/acceptance/acceptance/forms/FormInterface.feature
@@ -2,23 +2,7 @@
 Feature: Form interface
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
   Scenario: FormInterface test
     Given I have the following code
           """

--- a/tests/acceptance/acceptance/forms/FormView.feature
+++ b/tests/acceptance/acceptance/forms/FormView.feature
@@ -2,23 +2,7 @@
 Feature: Form view
 
   Background:
-    Given I have the following config
-      """
-      <?xml version="1.0"?>
-      <psalm errorLevel="1">
-        <projectFiles>
-          <directory name="."/>
-          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
-        </projectFiles>
-
-        <plugins>
-          <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
-        </plugins>
-        <issueHandlers>
-          <UnusedVariable errorLevel="info"/>
-        </issueHandlers>
-      </psalm>
-      """
+    Given I have Symfony plugin enabled
   Scenario: FormView test
     Given I have the following code
           """


### PR DESCRIPTION
I was quite annoyed with situation in tests of this plugin where people just keep copy pasting same psalm config over and over. Getting rid of that boilerplate helps with highlighting differences that matter.

The only features remaining that are still using "I have the following config" are TwigTainting related ones, because they are changing psalm config too much.


I don't like suppressing UnusedVariable either, but that's what most tests currently do so let's start with that and we can explicitly declare it as a suppressed issue in feature files later.