### PR TITLE
Allow covariants of object for message of Envelope (#154)

### DIFF
--- a/src/Stubs/common/Envelope.stubphp
+++ b/src/Stubs/common/Envelope.stubphp
@@ -5,7 +5,7 @@ namespace Symfony\Component\Messenger;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**
- * @template M of object
+ * @template-covariant M of object
  */
 final class Envelope
 {

--- a/tests/acceptance/acceptance/Envelope.feature
+++ b/tests/acceptance/acceptance/Envelope.feature
@@ -185,3 +185,13 @@ Feature: Messenger Envelope
       | Type  | Message            |
       | Trace | $message: stdClass |
     And I see no other errors
+
+  Scenario: Message can be any object
+    Given I have the following code
+      """
+      /** @psalm-suppress UnusedParam */
+      function foo(Envelope $envelope): void {};
+      foo($envelope);
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
Discovered this while working on a project where I implemented a `RetryStrategyInterface`.
I think the default case is that methods don't really care what kind of object is inside the envelope, so allowing covariants seems to be fine.