### PR TITLE
Upgrade Psalm interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1 || ^8.0",
         "ext-simplexml": "*",
         "symfony/framework-bundle": "^3.0 || ^4.0 || ^5.0",
-        "vimeo/psalm": "^4.6.1"
+        "vimeo/psalm": "^4.8"
     },
     "require-dev": {
         "symfony/form": "^4.0 || ^5.0",

--- a/src/Handler/AnnotationHandler.php
+++ b/src/Handler/AnnotationHandler.php
@@ -4,19 +4,19 @@ namespace Psalm\SymfonyPsalmPlugin\Handler;
 
 use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassLike;
-use Psalm\Codebase;
-use Psalm\FileSource;
-use Psalm\Plugin\Hook\AfterClassLikeVisitInterface;
-use Psalm\Storage\ClassLikeStorage;
+use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
 
 class AnnotationHandler implements AfterClassLikeVisitInterface
 {
     /**
      * {@inheritdoc}
      */
-    public static function afterClassLikeVisit(ClassLike $stmt, ClassLikeStorage $storage, FileSource $statements_source, Codebase $codebase, array &$file_replacements = [])
+    public static function afterClassLikeVisit(AfterClassLikeVisitEvent $event)
     {
+        $stmt = $event->getStmt();
+        $storage = $event->getStorage();
+
         if (!$stmt instanceof Class_) {
             return;
         }

--- a/src/Handler/ContainerDependencyHandler.php
+++ b/src/Handler/ContainerDependencyHandler.php
@@ -3,12 +3,10 @@
 namespace Psalm\SymfonyPsalmPlugin\Handler;
 
 use PhpParser\Node;
-use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\IssueBuffer;
-use Psalm\Plugin\Hook\AfterFunctionLikeAnalysisInterface;
-use Psalm\StatementsSource;
-use Psalm\Storage\FunctionLikeStorage;
+use Psalm\Plugin\EventHandler\AfterFunctionLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent;
 use Psalm\SymfonyPsalmPlugin\Issue\ContainerDependency;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -17,13 +15,11 @@ class ContainerDependencyHandler implements AfterFunctionLikeAnalysisInterface
     /**
      * {@inheritdoc}
      */
-    public static function afterStatementAnalysis(
-        Node\FunctionLike $stmt,
-        FunctionLikeStorage $classlike_storage,
-        StatementsSource $statements_source,
-        Codebase $codebase,
-        array &$file_replacements = []
-    ): ?bool {
+    public static function afterStatementAnalysis(AfterFunctionLikeAnalysisEvent $event): ?bool
+    {
+        $stmt = $event->getStmt();
+        $statements_source = $event->getStatementsSource();
+
         if ($stmt instanceof Node\Stmt\ClassMethod && '__construct' === $stmt->name->name) {
             foreach ($stmt->params as $param) {
                 if ($param->type instanceof Node\Name && ContainerInterface::class === $param->type->getAttribute('resolvedName')) {

--- a/src/Handler/DoctrineQueryBuilderHandler.php
+++ b/src/Handler/DoctrineQueryBuilderHandler.php
@@ -3,31 +3,25 @@
 namespace Psalm\SymfonyPsalmPlugin\Handler;
 
 use PhpParser\Node\Expr;
-use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\IssueBuffer;
-use Psalm\Plugin\Hook\AfterMethodCallAnalysisInterface;
-use Psalm\StatementsSource;
+use Psalm\Plugin\EventHandler\AfterMethodCallAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
 use Psalm\SymfonyPsalmPlugin\Issue\QueryBuilderSetParameter;
-use Psalm\Type\Union;
 
 class DoctrineQueryBuilderHandler implements AfterMethodCallAnalysisInterface
 {
     /**
      * {@inheritdoc}
      */
-    public static function afterMethodCallAnalysis(
-        Expr $expr,
-        string $method_id,
-        string $appearing_method_id,
-        string $declaring_method_id,
-        Context $context,
-        StatementsSource $statements_source,
-        Codebase $codebase,
-        array &$file_replacements = [],
-        Union &$return_type_candidate = null
-    ): void {
+    public static function afterMethodCallAnalysis(AfterMethodCallAnalysisEvent $event): void
+    {
+        $expr = $event->getExpr();
+        $declaring_method_id = $event->getDeclaringMethodId();
+        $statements_source = $event->getStatementsSource();
+        $context = $event->getContext();
+
         if ('Doctrine\ORM\QueryBuilder::setparameter' === $declaring_method_id) {
             if (isset($expr->args[2])) {
                 return;

--- a/src/Handler/HeaderBagHandler.php
+++ b/src/Handler/HeaderBagHandler.php
@@ -4,10 +4,8 @@ namespace Psalm\SymfonyPsalmPlugin\Handler;
 
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Scalar\String_;
-use Psalm\CodeLocation;
-use Psalm\Context;
-use Psalm\Plugin\Hook\MethodReturnTypeProviderInterface;
-use Psalm\StatementsSource;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TInt;
@@ -26,17 +24,14 @@ class HeaderBagHandler implements MethodReturnTypeProviderInterface
         ];
     }
 
-    public static function getMethodReturnType(
-        StatementsSource $source,
-        string $fq_classlike_name,
-        string $method_name_lowercase,
-        array $call_args,
-        Context $context,
-        CodeLocation $code_location,
-        ?array $template_type_parameters = null,
-        ?string $called_fq_classlike_name = null,
-        ?string $called_method_name_lowercase = null
-    ): ?Type\Union {
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $fq_classlike_name = $event->getFqClasslikeName();
+        $method_name_lowercase = $event->getMethodNameLowercase();
+        $call_args = $event->getCallArgs();
+        $source = $event->getSource();
+        $code_location = $event->getCodeLocation();
+
         if (HeaderBag::class !== $fq_classlike_name) {
             return null;
         }

--- a/src/Handler/RequiredSetterHandler.php
+++ b/src/Handler/RequiredSetterHandler.php
@@ -6,18 +6,18 @@ namespace Psalm\SymfonyPsalmPlugin\Handler;
 
 use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\NodeTraverser;
-use Psalm\Codebase;
-use Psalm\FileSource;
 use Psalm\Internal\PhpVisitor\AssignmentMapVisitor;
-use Psalm\Plugin\Hook\AfterClassLikeVisitInterface;
-use Psalm\Storage\ClassLikeStorage;
+use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
 
 class RequiredSetterHandler implements AfterClassLikeVisitInterface
 {
-    public static function afterClassLikeVisit(ClassLike $stmt, ClassLikeStorage $storage, FileSource $statements_source, Codebase $codebase, array &$file_replacements = [])
+    public static function afterClassLikeVisit(AfterClassLikeVisitEvent $event)
     {
+        $stmt = $event->getStmt();
+        $storage = $event->getStorage();
+
         if (!$stmt instanceof Class_) {
             return;
         }

--- a/src/Twig/CachedTemplatesMapping.php
+++ b/src/Twig/CachedTemplatesMapping.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Psalm\SymfonyPsalmPlugin\Twig;
 
-use Psalm\Codebase;
-use Psalm\Plugin\Hook\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
 use RuntimeException;
 
 /**
@@ -31,8 +31,10 @@ class CachedTemplatesMapping implements AfterCodebasePopulatedInterface
      */
     private static $cacheRegistry;
 
-    public static function afterCodebasePopulated(Codebase $codebase)
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event)
     {
+        $codebase = $event->getCodebase();
+
         if (null === self::$cachePath) {
             return;
         }

--- a/src/Twig/CachedTemplatesTainter.php
+++ b/src/Twig/CachedTemplatesTainter.php
@@ -7,17 +7,14 @@ namespace Psalm\SymfonyPsalmPlugin\Twig;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
-use Psalm\CodeLocation;
-use Psalm\Context;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\MethodCallAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
-use Psalm\Plugin\Hook\MethodReturnTypeProviderInterface;
-use Psalm\StatementsSource;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 use RuntimeException;
 use Twig\Environment;
-use Twig\Template;
 
 /**
  * This hook transforms a call to `Twig\Environment::render()` in a call to the actual twig compiled template `doDisplay()` method.
@@ -29,17 +26,13 @@ class CachedTemplatesTainter implements MethodReturnTypeProviderInterface
         return [Environment::class];
     }
 
-    public static function getMethodReturnType(
-        StatementsSource $source,
-        string $fq_classlike_name,
-        string $method_name_lowercase,
-        array $call_args,
-        Context $context,
-        CodeLocation $code_location,
-        ?array $template_type_parameters = null,
-        ?string $called_fq_classlike_name = null,
-        ?string $called_method_name_lowercase = null
-    ): ?Union {
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $source = $event->getSource();
+        $method_name_lowercase = $event->getMethodNameLowercase();
+        $context = $event->getContext();
+        $call_args = $event->getCallArgs();
+
         if (!$source instanceof StatementsAnalyzer) {
             throw new RuntimeException(sprintf('The %s::%s hook can only be called using a %s.', __CLASS__, __METHOD__, StatementsAnalyzer::class));
         }

--- a/tests/acceptance/acceptance/Annotation.feature
+++ b/tests/acceptance/acceptance/Annotation.feature
@@ -46,5 +46,5 @@ Feature: Annotation class
     When I run Psalm
     Then I see these errors
       | Type                        | Message                                                                                              |
-      | PropertyNotSetInConstructor | Property Foo::$foo is not defined in constructor of Foo and in any methods called in the constructor |
+      | PropertyNotSetInConstructor | Property Foo::$foo is not defined in constructor of Foo or in any methods called in the constructor |
     And I see no other errors

--- a/tests/acceptance/acceptance/RequiredSetter.feature
+++ b/tests/acceptance/acceptance/RequiredSetter.feature
@@ -42,5 +42,5 @@ Feature: Annotation class
     When I run Psalm
     Then I see these errors
       | Type                        | Message                                                                                                                           |
-      | PropertyNotSetInConstructor | Property MyServiceB::$a is not defined in constructor of MyServiceB and in any private or final methods called in the constructor |
+      | PropertyNotSetInConstructor | Property MyServiceB::$a is not defined in constructor of MyServiceB or in any private or final methods called in the constructor |
     And I see no other errors

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -49,6 +49,7 @@ Feature: Tainting
     Then I see these errors
       | Type         | Message               |
       | TaintedHtml  | Detected tainted HTML |
+      | TaintedHtml  | Detected tainted HTML |
     And I see no other errors
     Examples:
       | property |

--- a/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature
+++ b/tests/acceptance/acceptance/TwigTaintingWithAnalyzer.feature
@@ -97,8 +97,9 @@ Feature: Twig tainting with analyzer
       """
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors
 
   Scenario: One tainted parameter (in a variable) of the twig template (named in a variable) is displayed with only the raw filter
@@ -117,8 +118,9 @@ Feature: Twig tainting with analyzer
       """
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors
 
   Scenario: One tainted parameter of the twig rendering is displayed with some filter followed by the raw filter
@@ -135,8 +137,9 @@ Feature: Twig tainting with analyzer
       """
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors
 
   Scenario: One tainted parameter of the twig rendering is displayed with the raw filter followed by some other filter
@@ -177,8 +180,9 @@ Feature: Twig tainting with analyzer
       """
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors
 
   Scenario: One tainted parameter of the twig template is displayed with autoescaping deactivated
@@ -197,8 +201,9 @@ Feature: Twig tainting with analyzer
       """
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors
 
   Scenario: One tainted parameter of the twig template is assigned to a variable and this variable is displayed
@@ -217,8 +222,9 @@ Feature: Twig tainting with analyzer
       """
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors
 
   Scenario: One tainted parameter of the twig (oddly located) template is displayed with only the raw filter
@@ -259,6 +265,7 @@ Feature: Twig tainting with analyzer
       """
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors

--- a/tests/acceptance/acceptance/TwigTaintingWithCachedTemplates.feature
+++ b/tests/acceptance/acceptance/TwigTaintingWithCachedTemplates.feature
@@ -85,8 +85,9 @@ Feature: Twig tainting with cached templates
     And the "index.html.twig" template is compiled in the "cache/twig/" directory
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors
 
 #  Scenario: One tainted parameter (in a variable) of the twig template (named in a variable) is displayed with only the raw filter
@@ -126,8 +127,9 @@ Feature: Twig tainting with cached templates
     And the last compiled template got his alias changed to "@Acme/index.html.twig"
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors
 
   Scenario: The template has a taint sink and is aliased using the old notation
@@ -146,8 +148,9 @@ Feature: Twig tainting with cached templates
     And the last compiled template got his alias changed to "AcmeBundle::index.html.twig"
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors
 
   Scenario: The template has a taint sink and is rendered using the old alias notation
@@ -166,6 +169,7 @@ Feature: Twig tainting with cached templates
     And the last compiled template got his alias changed to "@Acme/index.html.twig"
     When I run Psalm with taint analysis
     Then I see these errors
-      | Type         | Message               |
-      | TaintedHtml  | Detected tainted HTML |
+      | Type                  | Message                                    |
+      | TaintedHtml           | Detected tainted HTML                      |
+      | TaintedTextWithQuotes | Detected tainted text with possible quotes |
     And I see no other errors


### PR DESCRIPTION
Psalm 4.4 introduced new interfaces for hook classes (and rebranded them EventHandlers). Psalm 4.8 deprecated older interfaces, and we plan to remove them in Psalm 5.

Test failures seem to be caused by unrelated Psalm changes.