### PR TITLE
Add missing use statements to AbstractController.stubphp for Symfony4

### DIFF
--- a/src/Stubs/4/AbstractController.stubphp
+++ b/src/Stubs/4/AbstractController.stubphp
@@ -4,6 +4,8 @@ namespace Symfony\Bundle\FrameworkBundle\Controller;
 
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 
 class AbstractController implements ServiceSubscriberInterface
 {


### PR DESCRIPTION
Similar to #161 - this adds the missing use statements to the Symfony 4 version