### PR TITLE
Add FileLocator::locate stub and test

### DIFF
--- a/src/Stubs/common/FileLocator.stubphp
+++ b/src/Stubs/common/FileLocator.stubphp
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Config;
+
+class FileLocator implements FileLocatorInterface
+{
+    /**
+     * @psalm-template TFirst as bool
+     * @psalm-param TFirst $first
+     * @psalm-return (TFirst is true ? string : array)
+     */
+    public function locate(string $name, string $currentPath = null, bool $first = true) {}
+}

--- a/src/Stubs/common/FileLocatorInterface.stubphp
+++ b/src/Stubs/common/FileLocatorInterface.stubphp
@@ -2,12 +2,12 @@
 
 namespace Symfony\Component\Config;
 
-class FileLocator implements FileLocatorInterface
+interface FileLocatorInterface
 {
     /**
      * @psalm-template TFirst as bool
      * @psalm-param TFirst $first
      * @psalm-return (TFirst is true ? string : array)
      */
-    public function locate(string $name, string $currentPath = null, bool $first = true) {}
+    public function locate(string $name, string $currentPath = null, bool $first = true);
 }

--- a/tests/acceptance/acceptance/FileLocator.feature
+++ b/tests/acceptance/acceptance/FileLocator.feature
@@ -1,0 +1,33 @@
+@symfony-common
+Feature: FileLocator locate
+
+  Background:
+    Given I have Symfony plugin enabled
+
+  Scenario: FileLocator locate method return type should be `string` when third argument is true
+    Given I have the following code
+      """
+      <?php
+      function test(): string
+      {
+        $locator = new \Symfony\Component\Config\FileLocator(__DIR__);
+
+        return $locator->locate(__FILE__);
+      }
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: FileLocator locate method return type should be `array` when third argument is false
+    Given I have the following code
+      """
+      <?php
+      function test(): array
+      {
+        $locator = new \Symfony\Component\Config\FileLocator(__DIR__);
+
+        return $locator->locate(__FILE__, null, false);
+      }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
This PR adds a stub for the Symfony Config component's FileLocator::locate method. 

The method accepts a boolean argument which effects its return type, returning either a string or an array, but even when we know a string will always be returned, Psalm gives `InvalidReturnType` and `InvalidReturnStatement` errors when typehinting calling code's return value to a string e.g:

```php
function returnsString(): string
{
  $locator = new \Symfony\Component\Config\FileLocator(__DIR__);

  return $locator->locate(__FILE__);
}
```

```
InvalidReturnStatement: The inferred type 'array<array-key, mixed>|string' does not match the declared return type 'string' for returnsString
InvalidReturnType: The declared return type 'string' for returnsString is incorrect, got 'array<array-key, mixed>|string'
```

This PR resolves the errors by using [conditional types](https://psalm.dev/docs/annotating_code/type_syntax/conditional_types/).