### PR TITLE
prevent service subscribers overwriting already known service definitions

### DIFF
--- a/src/Handler/ContainerHandler.php
+++ b/src/Handler/ContainerHandler.php
@@ -188,9 +188,11 @@ class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterClassLi
                 $key = $arrayItem->key;
                 $serviceId = $key instanceof String_ ? $key->value : $className;
 
-                $service = new Service($serviceId, $className);
-                $service->setIsPublic(true);
-                self::$containerMeta->add($service);
+                if (null === self::$containerMeta->get($className)) {
+                    $service = new Service($serviceId, $className);
+                    $service->setIsPublic(true);
+                    self::$containerMeta->add($service);
+                }
 
                 $codebase->queueClassLikeForScanning($className);
                 $fileStorage->referenced_classlikes[strtolower($className)] = $className;


### PR DESCRIPTION
This is my attempt and fixing #193.

Service subscribers are overwriting services already known via the containerXml.
I believe this to be a bug.

Note the acceptance test, and that psalm knows that the type is the concrete `Symfony\Component\HttpKernel\HttpKernel`

Comments welcome!

Thanks
