### PR TITLE
Option are always nullable when value is optional

### DIFF
--- a/src/Handler/ConsoleHandler.php
+++ b/src/Handler/ConsoleHandler.php
@@ -189,7 +189,10 @@ class ConsoleHandler implements AfterMethodCallAnalysisInterface
 
         $defaultParam = $normalizedParams['default'];
         if ($defaultParam) {
-            $returnTypes->removeType('null');
+            if (0 === ($mode & InputOption::VALUE_OPTIONAL)) {
+                $returnTypes->removeType('null');
+            }
+
             if ($defaultParam->value instanceof Expr\ConstFetch) {
                 switch ($defaultParam->value->name->parts[0]) {
                     case 'null':

--- a/tests/acceptance/acceptance/console/ConsoleOption.feature
+++ b/tests/acceptance/acceptance/console/ConsoleOption.feature
@@ -78,6 +78,7 @@ Feature: ConsoleOption
           $this->addOption('option3', null, InputOption::VALUE_NONE, '', true);
           $this->addOption('option4', null, InputOption::VALUE_OPTIONAL, '', false);
           $this->addOption('option5', null, InputOption::VALUE_OPTIONAL, '', null);
+          $this->addOption('option6', null, InputOption::VALUE_OPTIONAL, '', 'default');
         }
 
         public function execute(InputInterface $input, OutputInterface $output): int
@@ -97,6 +98,9 @@ Feature: ConsoleOption
           /** @psalm-trace $option5 */
           $option5 = $input->getOption('option5');
 
+          /** @psalm-trace $option6 */
+          $option6 = $input->getOption('option6');
+
           return 0;
         }
       }
@@ -109,6 +113,7 @@ Feature: ConsoleOption
       | Trace | $option3: bool               |
       | Trace | $option4: bool               |
       | Trace | $option5: null\|string       |
+      | Trace | $option6: null\|string       |
     And I see no other errors
 
   Scenario: Asserting options return types have inferred with -- prefix in names


### PR DESCRIPTION
As promise, I made the PR for https://github.com/psalm/psalm-plugin-symfony/issues/195 @seferov 

Tests are failing but I don't think it's related... And I'm not sure how to fix them. Any idea ?