### PR TITLE
Fix to incorrect signature of ParamConverter

### DIFF
--- a/src/Stubs/common/ParamConverter.stubphp
+++ b/src/Stubs/common/ParamConverter.stubphp
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sensio\Bundle\FrameworkExtraBundle\Configuration;
+
+class ParamConverter extends ConfigurationAnnotation
+{
+    /**
+     * @return null|class-string
+     */
+    public function getClass()
+    {
+    }
+}


### PR DESCRIPTION
[ParamConverter](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/bb996b0d4b573df2f3534fbe9cf3fe60052cde81/src/Configuration/ParamConverter.php#L111) has incorrect signature for ``getClass`` method i.e. it says return value will always be string but that is not true.

Even the included [DoctrineParamConverter](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/src/Request/ParamConverter/DoctrineParamConverter.php#L294) checks for nullability.

This PR fixes the nullability problem and uses ``class-string`` instead of ``string``.
