### PR TITLE
Use Symfony SplFileInfo in Finder

### DIFF
--- a/src/Stubs/common/Component/Finder/Finder.stubphp
+++ b/src/Stubs/common/Component/Finder/Finder.stubphp
@@ -6,7 +6,7 @@ use Countable;
 use IteratorAggregate;
 
 /**
- * @implements IteratorAggregate<string, \SplFileInfo>
+ * @implements IteratorAggregate<string, SplFileInfo>
  */
 class Finder implements IteratorAggregate, Countable
 {

--- a/tests/acceptance/acceptance/Finder.feature
+++ b/tests/acceptance/acceptance/Finder.feature
@@ -10,6 +10,7 @@ Feature: Finder
       <?php
 
       use Symfony\Component\Finder\Finder;
+      use Symfony\Component\Finder\SplFileInfo;
 
       class Test
       {


### PR DESCRIPTION
According to https://symfony.com/doc/current/components/finder.html#usage, we can use `Symfony\Component\Finder\SplFileInfo` that extends core `SplFileInfo`.