### PR TITLE
Fix the case where the path dir does not exist

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -103,6 +103,11 @@ class Plugin implements PluginEntryPointInterface
 
     private function addStubs(RegistrationInterface $api, string $path): void
     {
+        if (!is_dir($path)) {
+            // e.g. looking for stubs for version 3, but there aren't any at time of writing, so don't try and load them.
+            return;
+        }
+
         $a = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path));
         foreach ($a as $file) {
             if (!$file->isDir()) {


### PR DESCRIPTION
Fixes #214 by checking for the presence of the directory first.