### PR TITLE
Create Kernel.stubphp

### DIFF
--- a/src/Stubs/common/Component/HttpKernel/Kernel.stubphp
+++ b/src/Stubs/common/Component/HttpKernel/Kernel.stubphp
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\HttpKernel;
+
+class Kernel
+{
+    /**
+     * @var string
+     */
+    protected $environment;
+}

--- a/tests/acceptance/acceptance/Kernel.feature
+++ b/tests/acceptance/acceptance/Kernel.feature
@@ -1,0 +1,27 @@
+@symfony-5
+Feature: Kernel
+
+  Background:
+    Given I have Symfony plugin enabled
+
+  Scenario: MixedOperand error about $environment is not raised
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+      use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+      use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+      abstract class Kernel extends BaseKernel
+      {
+          use MicroKernelTrait;
+
+          protected function configureContainer(ContainerConfigurator $container): void
+          {
+              $container->import('../config/{packages}/' . $this->environment . '/*.yaml');
+          }
+      }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
```
class Kernel extends BaseKernel
{
    use MicroKernelTrait;

    protected function configureContainer(ContainerConfigurator $container): void
    {
        $container->import('../config/{packages}/*.yaml');
        $container->import('../config/{packages}/' . $this->environment . '/*.yaml');
		// ...
    }
}
```

Psalm:

```
ERROR: MixedOperand
at /app/src/Kernel.php:17:54
Right operand cannot be mixed (see https://psalm.dev/059)
        $container->import('../config/{packages}/' . $this->environment . '/*.yaml');
```