### PR TITLE
Fixed Finder key and value

### DIFF
--- a/src/Stubs/common/Component/Finder/Finder.stubphp
+++ b/src/Stubs/common/Component/Finder/Finder.stubphp
@@ -6,8 +6,12 @@ use Countable;
 use IteratorAggregate;
 
 /**
- * @implements IteratorAggregate<string, SplFileInfo>
+ * @implements IteratorAggregate<non-empty-string, SplFileInfo>
  */
 class Finder implements IteratorAggregate, Countable
 {
+    /**
+     * @return \Iterator<non-empty-string, SplFileInfo>
+     */
+    public function getIterator() {}
 }

--- a/tests/acceptance/acceptance/Finder.feature
+++ b/tests/acceptance/acceptance/Finder.feature
@@ -10,7 +10,6 @@ Feature: Finder
       <?php
 
       use Symfony\Component\Finder\Finder;
-      use Symfony\Component\Finder\SplFileInfo;
 
       function run(Finder $finder): void
       {

--- a/tests/acceptance/acceptance/Finder.feature
+++ b/tests/acceptance/acceptance/Finder.feature
@@ -4,7 +4,7 @@ Feature: Finder
   Background:
     Given I have Symfony plugin enabled
 
-  Scenario: Finder should be considered as an IteratorAggregate of SplFileInfo
+  Scenario: Finder is an IteratorAggregate with non-empty-string key and SplFileInfo value
     Given I have the following code
       """
       <?php
@@ -12,18 +12,18 @@ Feature: Finder
       use Symfony\Component\Finder\Finder;
       use Symfony\Component\Finder\SplFileInfo;
 
-      class Test
+      function run(Finder $finder): void
       {
-          /**
-           * @param iterable<SplFileInfo> $files
-           */
-          public static function run(iterable $files): void
-          {
+          foreach ($finder as $key => $file) {
+              /** @psalm-trace $key */
+              echo $key;
+              /** @psalm-trace $file */
           }
       }
-
-      $finder = new Finder();
-      Test::run($finder);
       """
     When I run Psalm
-    Then I see no errors
+    Then I see these errors
+      | Type  | Message                                     |
+      | Trace | $key: non-empty-string                      |
+      | Trace | $file: Symfony\Component\Finder\SplFileInfo |
+    And I see no other errors


### PR DESCRIPTION
When `getIterator` is not annotated, Psalm thinks that iterator value is `SplFileInfo|mixed`.

The key is always non-empty, because it's a realpath.