### PR TITLE
Fix Request stubs for Symfony 6

### DIFF
--- a/src/Stubs/6/Component/HttpFoundation/InputBag.stubphp
+++ b/src/Stubs/6/Component/HttpFoundation/InputBag.stubphp
@@ -2,14 +2,17 @@
 
 namespace Symfony\Component\HttpFoundation;
 
+/**
+ * @template T of string|int|float|bool
+ */
 final class InputBag extends ParameterBag
 {
     /**
      * Returns a string input value by name.
      *
-     * @template D of string|int|float|bool|null
+     * @template D of T|null
      * @psalm-param D $default
-     * @psalm-return string|int|float|bool|D
+     * @psalm-return D|T
      * @psalm-taint-source input
      */
     public function get(string $key, $default = null) {}

--- a/src/Stubs/6/Component/HttpFoundation/Request.stubphp
+++ b/src/Stubs/6/Component/HttpFoundation/Request.stubphp
@@ -8,4 +8,14 @@ class Request
      * @psalm-var InputBag
      */
     public $request;
+
+    /**
+     * @psalm-var InputBag<string>
+     */
+    public $query;
+
+    /**
+     * @psalm-var InputBag<string>
+     */
+    public $cookies;
 }


### PR DESCRIPTION
I'm sorry @seferov  

Seems like my fork wasn't up to date, so I copied pasted some old stubs without the following fix https://github.com/psalm/psalm-plugin-symfony/pull/218/files

This PR is fixing the Symfony 6 stubs.