### PR TITLE
Add getSession stub

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,7 +55,12 @@ jobs:
           restore-keys: php-${{ matrix.php-version }}-psalm-
 
       - name: "Run vimeo/psalm"
-        run: vendor/bin/psalm --find-dead-code --find-unused-psalm-suppress --shepherd --show-info=false --stats --output-format=github
+        run: vendor/bin/psalm --find-dead-code --find-unused-psalm-suppress --shepherd --show-info=false --stats --output-format=github --php-version=${{ matrix.php-version }}
+        if: matrix.php-version != '8.0'
+
+      - name: "Run vimeo/psalm"
+        run: vendor/bin/psalm --find-dead-code --find-unused-psalm-suppress --shepherd --show-info=false --stats --output-format=github --php-version=8.0
+        if: matrix.php-version == '8.0'
 
   tests:
     name: "Tests (PHP: ${{matrix.php-version}}, Symfony: ${{matrix.symfony-version}})"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -97,6 +97,8 @@ jobs:
             symfony-version: 6
           - php-version: 8.0
             symfony-version: 3
+          - php-version: 8.0
+            symfony-version: 6
 
     steps:
       - name: "Checkout"

--- a/src/Stubs/5/Component/HttpFoundation/Request.stubphp
+++ b/src/Stubs/5/Component/HttpFoundation/Request.stubphp
@@ -18,4 +18,9 @@ class Request
      * @psalm-var InputBag<string>
      */
     public $cookies;
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Session\Session
+     */
+    public function getSession(): SessionInterface;
 }

--- a/src/Stubs/6/Component/HttpFoundation/Request.stubphp
+++ b/src/Stubs/6/Component/HttpFoundation/Request.stubphp
@@ -18,4 +18,9 @@ class Request
      * @psalm-var InputBag<string>
      */
     public $cookies;
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Session\Session
+     */
+    public function getSession(): SessionInterface;
 }

--- a/src/Twig/CachedTemplatesTainter.php
+++ b/src/Twig/CachedTemplatesTainter.php
@@ -55,13 +55,13 @@ class CachedTemplatesTainter implements MethodReturnTypeProviderInterface
         try {
             $templateName = TwigUtils::extractTemplateNameFromExpression($call_args[0]->value, $source);
         } catch (TemplateNameUnresolvedException $exception) {
-            if ($statements_source instanceof StatementsAnalyzer) {
-                $statements_source->getProjectAnalyzer()->progress->debug($exception->getMessage());
+            if ($source instanceof StatementsAnalyzer) {
+                $source->getProjectAnalyzer()->progress->debug($exception->getMessage());
             }
 
             return null;
         }
-        
+
         $cacheClassName = CachedTemplatesMapping::getCacheClassName($templateName);
 
         $context->vars_in_scope['$__fake_twig_env_var__'] = new Union([

--- a/tests/acceptance/acceptance/InputBag.feature
+++ b/tests/acceptance/acceptance/InputBag.feature
@@ -1,4 +1,4 @@
-@symfony-5
+@symfony-5 @symfony-6
 Feature: InputBag get return type
 
   Background:

--- a/tests/acceptance/acceptance/Kernel.feature
+++ b/tests/acceptance/acceptance/Kernel.feature
@@ -1,4 +1,4 @@
-@symfony-5
+@symfony-5 @symfony-6
 Feature: Kernel
 
   Background:

--- a/tests/acceptance/acceptance/ParameterBag.feature
+++ b/tests/acceptance/acceptance/ParameterBag.feature
@@ -1,4 +1,4 @@
-@symfony-4 @symfony-5
+@symfony-4 @symfony-5 @symfony-6
 Feature: ParameterBag
 
   Background:

--- a/tests/acceptance/acceptance/RequestSession.feature
+++ b/tests/acceptance/acceptance/RequestSession.feature
@@ -1,0 +1,25 @@
+@symfony-5 @symfony-6
+Feature: Request getSessions
+  Symfony Request getSession method is returning a Session
+
+  Background:
+    Given I have Symfony plugin enabled
+    And I have the following code preamble
+      """
+      <?php
+      use Symfony\Component\HttpFoundation\Request;
+      """
+
+  Scenario: Asserting '$request->getSession()' has a Flashbag
+    Given I have the following code
+      """
+      class App
+      {
+        public function index(Request $request): void
+        {
+          $request->getSession()->getFlashBag();
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/acceptance/ServiceSubscriber.feature
+++ b/tests/acceptance/acceptance/ServiceSubscriber.feature
@@ -1,4 +1,4 @@
-@symfony-4 @symfony-5
+@symfony-4 @symfony-5 @symfony-6
 Feature: Service Subscriber
 
   Background:

--- a/tests/acceptance/acceptance/Tainting.feature
+++ b/tests/acceptance/acceptance/Tainting.feature
@@ -1,4 +1,4 @@
-@symfony-5
+@symfony-5 @symfony-6
 Feature: Tainting
 
   Background:

--- a/tests/acceptance/acceptance/TestContainerService.feature
+++ b/tests/acceptance/acceptance/TestContainerService.feature
@@ -1,4 +1,4 @@
-@symfony-4 @symfony-5
+@symfony-4 @symfony-5 @symfony-6
 Feature: Test Container service
 
   Background:

--- a/tests/acceptance/acceptance/console/ConsoleOption.feature
+++ b/tests/acceptance/acceptance/console/ConsoleOption.feature
@@ -1,4 +1,4 @@
-@symfony-4 @symfony-5
+@symfony-4 @symfony-5 @symfony-6
 Feature: ConsoleOption
 
   Background:

--- a/tests/acceptance/acceptance/forms/AbstractTypeExtension.feature
+++ b/tests/acceptance/acceptance/forms/AbstractTypeExtension.feature
@@ -1,4 +1,4 @@
-@symfony-5
+@symfony-5 @symfony-6
 Feature: FormType templates
 
   Background:

--- a/tests/acceptance/acceptance/forms/Form.feature
+++ b/tests/acceptance/acceptance/forms/Form.feature
@@ -1,4 +1,4 @@
-@symfony-4, @symfony-5
+@symfony-4, @symfony-5, @symfony-6
 Feature: Form test
 
   Background:


### PR DESCRIPTION
Hi @seferov 

There was the following discussion on phpstan-symfony https://github.com/phpstan/phpstan-symfony/pull/233.

For 99% of the symfony users, `$request->getSession()` is returning a Session with the `getFlashbag` method which is not in SessionInterface. In the commit https://github.com/phpstan/phpstan-symfony/commit/012305dab7a08f4e1a7158e01d7b4bccfbc6fa31, phpstan update the stub to make people life easier and avoiding the extract check `instanceof Session`.

I recommend psalm plugin to do the same because using both plugin gives the following issue.
-> without the check `assert($session instanceof Session)`, psalm say the `getFlashbag` method doesn't exists
-> with the check, phpstan say the `assert($session instanceof Session)` check is always true.
