### PR TITLE
[Twig taint analysis] Support `AbstractController::render()` and Symfony+custom twig extensions

### DIFF
--- a/src/Twig/AnalyzedTemplatesTainter.php
+++ b/src/Twig/AnalyzedTemplatesTainter.php
@@ -17,6 +17,7 @@ use Psalm\StatementsSource;
 use Psalm\SymfonyPsalmPlugin\Exception\TemplateNameUnresolvedException;
 use Psalm\Type\Atomic\TKeyedArray;
 use RuntimeException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Twig\Environment;
 
 /**
@@ -34,7 +35,7 @@ class AnalyzedTemplatesTainter implements AfterMethodCallAnalysisInterface
 
         if (
             null === $codebase->taint_flow_graph
-            || !$expr instanceof MethodCall || $method_id !== Environment::class.'::render' || empty($expr->args)
+            || !$expr instanceof MethodCall || !\in_array($method_id, [Environment::class.'::render', AbstractController::class.'::render', AbstractController::class.'::renderView'], true) || empty($expr->args)
             || !isset($expr->args[0]->value)
             || !isset($expr->args[1]->value)
         ) {


### PR DESCRIPTION
I'm quite interested in static analysis of twig templates, and the taint analysis features of Psalm. So I hope to contribute some more PRs in the future.

This first one fixes the 2 main points that make twig taint analysis work in the Symfony demo application:

* **Start taint analysis on `AbstractController::render()`** I guess that this isn't automatically picked up as the controller uses a service locator. Given this is the Symfony plugin, I think it's reasonable to directly check for Symfony methods (instead of the much more complex task of supporting service locators)
* **"Dummy" set-up enabled twig extensions** Currently, using any non-standard function or filter will create a fatal error. This PR solves it by inspecting the container meta (if configured) and enabling any extension that is also enabled in the application's container. Fixes #117