### PR TITLE
Stubs for extended form types

### DIFF
--- a/src/Stubs/common/Component/Form/Extension/Core/Type/SearchType.stubphp
+++ b/src/Stubs/common/Component/Form/Extension/Core/Type/SearchType.stubphp
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * @extends AbstractType<string>
+ */
+class SearchType extends AbstractType
+{
+}

--- a/src/Stubs/common/Component/Form/Extension/Core/Type/TextType.stubphp
+++ b/src/Stubs/common/Component/Form/Extension/Core/Type/TextType.stubphp
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * @extends AbstractType<string>
+ * @implements DataTransformerInterface<string, string>
+ */
+class TextType extends AbstractType implements DataTransformerInterface
+{
+}

--- a/src/Stubs/common/Component/Form/Extension/Core/Type/TextareaType.stubphp
+++ b/src/Stubs/common/Component/Form/Extension/Core/Type/TextareaType.stubphp
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * @extends AbstractType<string>
+ */
+class TextareaType extends AbstractType
+{
+}

--- a/tests/acceptance/acceptance/forms/ExtendedFormTypes.feature
+++ b/tests/acceptance/acceptance/forms/ExtendedFormTypes.feature
@@ -1,0 +1,46 @@
+@symfony-common
+Feature: Extended form types
+
+  Background:
+    Given I have Symfony plugin enabled
+  Scenario: Assert extends form types yields non-mixed values
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+      use Symfony\Component\Form\Extension\Core\Type\TextType;
+      use Symfony\Component\Form\Extension\Core\Type\SearchType;
+      use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+      class MyController extends AbstractController
+      {
+          public function text(): void
+          {
+              $form = $this->createForm(TextType::class);
+              $text = $form->getData();
+              /** @psalm-trace $text */
+          }
+
+          public function search(): void
+          {
+              $form = $this->createForm(SearchType::class);
+              $search = $form->getData();
+              /** @psalm-trace $search */
+          }
+
+          public function textarea(): void
+          {
+              $form = $this->createForm(TextareaType::class);
+              $textarea = $form->getData();
+              /** @psalm-trace $textarea */
+          }
+      }
+    """
+    When I run Psalm
+    Then I see these errors
+      | Type  | Message                       |
+      | Trace | $text: null\|string           |
+      | Trace | $search: null\|string         |
+      | Trace | $textarea: null\|string       |
+    And I see no other errors

--- a/tests/acceptance/acceptance/forms/FormBuilterInterface.feature
+++ b/tests/acceptance/acceptance/forms/FormBuilterInterface.feature
@@ -34,6 +34,5 @@ Feature: Form builder
     Then I see these errors
       | Type  | Message                                                         |
       | Trace | $form: Symfony\Component\Form\FormInterface<User>               |
-      | InvalidArgument | Argument 2 of Symfony\Component\Form\FormBuilderInterface::create expects class-string<Symfony\Component\Form\FormTypeInterface>\|null, stdClass::class provided |
+      | InvalidArgument | Argument 2 of Symfony\Component\Form\FormBuilderInterface::create expects class-string<Symfony\Component\Form\FormTypeInterface>\|null, but stdClass::class provided |
     And I see no other errors
-

--- a/tests/acceptance/acceptance/forms/FormConfigBuilterInterface.feature
+++ b/tests/acceptance/acceptance/forms/FormConfigBuilterInterface.feature
@@ -60,4 +60,3 @@ Feature: Form config builder
       | Trace | $submitData: User\|null                                         |
       | Trace | $postSubmitData: User\|null                                     |
     And I see no other errors
-

--- a/tests/acceptance/acceptance/forms/FormFactoryInterface.feature
+++ b/tests/acceptance/acceptance/forms/FormFactoryInterface.feature
@@ -27,5 +27,5 @@ Feature: Form factory
     When I run Psalm
     Then I see these errors
       | Type  | Message                       |
-      | InvalidArgument | Argument 1 of Symfony\Component\Form\FormFactoryInterface::create expects class-string<Symfony\Component\Form\FormTypeInterface>, stdClass::class provided |
+      | InvalidArgument | Argument 1 of Symfony\Component\Form\FormFactoryInterface::create expects class-string<Symfony\Component\Form\FormTypeInterface>, but stdClass::class provided |
     And I see no other errors


### PR DESCRIPTION
When form types are created from controller like this:



```php
public function __invoke()
{
	  $form = $this->createForm(SearchType::class);
	  $form->handleRequest($request);
	  if ($form->isSubmitted() && $form->isValid()) {
	  
		  $code = $form->getData(); // <--- mixed
	   
	  }
}
```

psalm thinks it is ``mixed``. 

These 3 stubs fixes cases that all work with ``string``. In few weeks, I will add other types after I confirm returned data.