### PR TITLE
Support TestContainer directly

### DIFF
--- a/src/Handler/ContainerHandler.php
+++ b/src/Handler/ContainerHandler.php
@@ -28,6 +28,7 @@ class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterClassLi
         'Symfony\Component\DependencyInjection\ContainerInterface',
         'Symfony\Bundle\FrameworkBundle\Controller\AbstractController',
         'Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait',
+        'Symfony\Bundle\FrameworkBundle\Test\TestContainer',
     ];
 
     /**


### PR DESCRIPTION
Since Symfony 6.1, `KernelTestCase::getContainer()` has a `@return TestContainer`  (https://github.com/symfony/symfony/pull/44695), which trips up Psalm:

```
ERROR: PropertyTypeCoercion - MyTest:16:25 - $this->client expects 'SomeService',  parent type 'null|object' provided (see https://psalm.dev/198)
        $this->client = static::getContainer()->get(SomeService::class);

ERROR: InternalMethod - MyTest.php:16:49 - The method Symfony\Bundle\FrameworkBundle\Test\TestContainer::get is internal to Symfony but called from MyTest (see https://psalm.dev/175)
        $this->client = static::getContainer()->get(SomeService::class);
```

Symfony’s `TestContainer` is indeed marked `@internal`. A first step is to add `Symfony\Bundle\FrameworkBundle\Test\TestContainer` to `ContainerHandler`, although it doesn’t yet fully resolve the problem.

See also https://github.com/symfony/symfony/issues/46483.