### PR TITLE
Improve statusTexts variable type in the Response stub

### DIFF
--- a/src/Stubs/common/Component/HttpFoundation/Response.stubphp
+++ b/src/Stubs/common/Component/HttpFoundation/Response.stubphp
@@ -5,6 +5,11 @@ namespace Symfony\Component\HttpFoundation;
 class Response
 {
     /**
+     * @var array<int, string>
+     */
+    public static $statusTexts;
+
+    /**
      * @throws \InvalidArgumentException When the HTTP status code is not valid
      * @psalm-taint-sink html $content
      */

--- a/tests/acceptance/acceptance/Response.feature
+++ b/tests/acceptance/acceptance/Response.feature
@@ -1,0 +1,18 @@
+@symfony-common
+Feature: Response
+
+  Background:
+    Given I have Symfony plugin enabled
+
+  Scenario: MixedAssignment error about $statusTexts is not raised
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Component\HttpFoundation\Response;
+
+      $message = Response::$statusTexts[Response::HTTP_INTERNAL_SERVER_ERROR];
+      """
+    When I run Psalm
+    Then I see no errors
+


### PR DESCRIPTION
This PR fixes MixedAssignment issue when when `Response::$statusTexts` map is used.

See https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/HttpFoundation/Response.php#L147