### PR TITLE
Do not distribute specific CI workflows, tests and analyzer configs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Directories and files we do not want to distribute
+/.*                 export-ignore
+/tests/             export-ignore
+/composer.lock      export-ignore
+/codeception.yml    export-ignore
+/phpunit.xml        export-ignore
+/psalm.xml          export-ignore
+/psalm-baseline.xml export-ignore


### PR DESCRIPTION
When plugin is set up end user get a list of files which a not needed like github, phpunit, psalm and other configs.
![image](https://user-images.githubusercontent.com/1302230/172112029-107c7b90-2cd2-4a31-8035-3084ab58677e.png)


So this PR adds **.gitattributes** file which won't allow to distribute such files and folders to the end user.
