### PR TITLE
[Routing] Do not raise ImplicitToStringCast when EnumRequirement is a…

### DIFF
--- a/src/Stubs/6/Component/Routing/Annotation/Route.stubphp
+++ b/src/Stubs/6/Component/Routing/Annotation/Route.stubphp
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\Component\Routing\Annotation;
+
+use Symfony\Component\Routing\Requirement\EnumRequirement;
+
+class Route
+{
+    /**
+     * @param string[]|EnumRequirement[] $requirements
+     * @param string[]|string $methods
+     * @param string[]|string $schemes
+     */
+    public function __construct(
+        string|array $path = null,
+        private ?string $name = null,
+        private array $requirements = [],
+        private array $options = [],
+        private array $defaults = [],
+        private ?string $host = null,
+        array|string $methods = [],
+        array|string $schemes = [],
+        private ?string $condition = null,
+        private ?int $priority = null,
+        string $locale = null,
+        string $format = null,
+        bool $utf8 = null,
+        bool $stateless = null,
+        private ?string $env = null
+    ) {
+    }
+}

--- a/tests/acceptance/acceptance/Route.feature
+++ b/tests/acceptance/acceptance/Route.feature
@@ -1,0 +1,32 @@
+@symfony-6
+Feature: Route
+
+  Background:
+    Given I have Symfony plugin enabled
+
+  Scenario: ImplicitToStringCast error is not raised when array of EnumRequirement is assigned
+    Given I have the following code
+      """
+      <?php
+
+      use Symfony\Component\Routing\Annotation\Route;
+      use Symfony\Component\Routing\Requirement\EnumRequirement;
+
+      #[Route(
+          '/route/{type}',
+          name: 'test',
+          methods: 'GET',
+          requirements: [
+              'type' => new EnumRequirement(DummyEnum::class),
+          ]
+      )]
+      class DummyAction {}
+
+
+      enum DummyEnum: string {
+          case TEST = 'test';
+      }
+      """
+    When I run Psalm
+    Then I see no errors
+


### PR DESCRIPTION
This PR handles ImplicitToStringCast when EnumRequirement is used in the Route requirements.

New feature introduced in Symfony Routing 6.1: https://symfony.com/blog/new-in-symfony-6-1-improved-routing-requirements-and-utf-8-parameters#using-php-backedenum-as-route-requirements

Current code does not pass test on PHP 8.1. Need to improve pipeline.

I'm not sure how to solve this kind of issue. I suppose smth wrong on Psalm end
```
1) Route: ImplicitToStringCast error is not raised when array of EnumRequirement is assigned
 Test  tests/acceptance/acceptance/Route.feature:ImplicitToStringCast error is not raised when array of EnumRequirement is assigned
 Step  Can see no errors 
 Fail  There were errors: 
| ParseError | Promoted property name clashes with an existing property         |
| ParseError | Promoted property requirements clashes with an existing property |
| ParseError | Promoted property options clashes with an existing property      |
| ParseError | Promoted property defaults clashes with an existing property     |
| ParseError | Promoted property host clashes with an existing property         |
| ParseError | Promoted property condition clashes with an existing property    |
| ParseError | Promoted property priority clashes with an existing property     |
| ParseError | Promoted property env clashes with an existing property          |
```