### PR TITLE
Fix compatibility with Sf6.1

### DIFF
--- a/src/Symfony/ContainerMeta.php
+++ b/src/Symfony/ContainerMeta.php
@@ -122,7 +122,9 @@ class ContainerMeta
                     $this->addServiceLocator($key, $id, $argument);
                 } elseif ($argument instanceof ServiceClosureArgument) {
                     foreach ($argument->getValues() as $value) {
-                        $this->addServiceLocator($key, $id, $value);
+                        if ($value instanceof Reference) {
+                            $this->addServiceLocator($key, $id, $value);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Hi @seferov, since this PR https://github.com/symfony/symfony/pull/45512, the ServiceClosureArgument is not always returning an array of Reference anymore. I tried to provide a fix. 

This works on my project.