### PR TITLE
[DI] skip checking naming convention for env var parameters

### DIFF
--- a/src/Handler/ContainerHandler.php
+++ b/src/Handler/ContainerHandler.php
@@ -65,7 +65,7 @@ class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterClassLi
         if (!self::isContainerMethod($declaring_method_id, 'get')) {
             if (self::isContainerMethod($declaring_method_id, 'getparameter')) {
                 $argument = $firstArg->value;
-                if ($argument instanceof String_ && !self::followsNamingConvention($argument->value) && false === strpos($argument->value, '\\')) {
+                if ($argument instanceof String_ && !self::followsParameterNamingConvention($argument->value) && false === strpos($argument->value, '\\')) {
                     IssueBuffer::accepts(
                         new NamingConventionViolation(new CodeLocation($statements_source, $argument)),
                         $statements_source->getSuppressedIssues()
@@ -184,6 +184,15 @@ class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterClassLi
             ),
             true
         );
+    }
+
+    private static function followsParameterNamingConvention(string $name): bool
+    {
+        if (0 === strpos($name, 'env(')) {
+            return true;
+        }
+
+        return self::followsNamingConvention($name);
     }
 
     /**

--- a/tests/acceptance/acceptance/NamingConventions.feature
+++ b/tests/acceptance/acceptance/NamingConventions.feature
@@ -105,3 +105,21 @@ Feature: Naming conventions
       | Type                      | Message                                                      |
       | NamingConventionViolation | Use snake_case for configuration parameter and service names |
     And I see no other errors
+
+  Scenario: No parameter naming convention violation when using environment variables
+    Given I have the following code
+      """
+      <?php
+
+      class SomeController
+      {
+        use \Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+        public function __invoke(): void
+        {
+          $this->container->getParameter('env(SOME_ENV_VAR)');
+        }
+      }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
fixes https://github.com/psalm/psalm-plugin-symfony/issues/264