### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 ```
 composer require --dev psalm/plugin-symfony
+vendor/bin/psalm --init
 vendor/bin/psalm-plugin enable psalm/plugin-symfony
 ```
 


### PR DESCRIPTION
For the first run seems to be need generate configuration file. Without config file i get error:
```
root@599da793f2ca:/var/www/sites/api-tp# php /root/composer.phar require --dev psalm/plugin-symfony
Warning from https://repo.packagist.org: Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/
Info from https://repo.packagist.org: #StandWithUkraine
Warning from https://repo.packagist.org: Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/
Info from https://repo.packagist.org: #StandWithUkraine
Using version ^3.1 for psalm/plugin-symfony
./composer.json has been updated
Loading composer repositories with package information
Warning from https://repo.packagist.org: Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies (including require-dev)
Restricting packages listed in "symfony/symfony" to "5.1.*"

Prefetching 10 packages 🎶 💨
  - Downloading (100%)

Package operations: 10 installs, 0 updates, 0 removals
  - Installing webmozart/path-util (2.3.0): Loading from cache
  - Installing openlss/lib-array2xml (1.0.0): Loading from cache
  - Installing netresearch/jsonmapper (v4.0.0): Loading from cache
  - Installing felixfbecker/language-server-protocol (v1.5.2): Loading from cache
  - Installing felixfbecker/advanced-json-rpc (v3.2.1): Loading from cache
  - Installing dnoegel/php-xdg-base-dir (v0.1.1): Loading from cache
  - Installing amphp/amp (v2.6.2): Loading from cache
  - Installing amphp/byte-stream (v1.8.1): Loading from cache
  - Installing vimeo/psalm (4.22.0): Loading from cache
  - Installing psalm/plugin-symfony (v3.1.8): Loading from cache
Package webmozart/path-util is abandoned, you should avoid using it. Use symfony/filesystem instead.
Writing lock file
Generating optimized autoload files
composer/package-versions-deprecated: Generating version class...
composer/package-versions-deprecated: ...done generating version class

Run composer recipes at any time to see the status of your Symfony recipes.

Executing script cache:clear [OK]
Executing script assets:install public [OK]

root@599da793f2ca:/var/www/sites/api-tp# vendor/bin/psalm-plugin enable psalm/plugin-symfony

In PluginList.php line 106:

  Cannot find Psalm config  


enable <pluginName>

root@599da793f2ca:/var/www/sites/api-tp# ./vendor/bin/psalm --init
Calculating best config level based on project files
Calculating best config level based on project files
Target PHP version: 7.4 (inferred from composer.json)
Scanning files...
Analyzing files...

EE░░░░░░░░░E░E░E░EE░░░EE░E░░EE░░E░░░EE░E░E░░░░E░E░E░E░EEEEEE  60 / 510 (11%)
░░░░E░EEE░E░░E░░░E░░░EEEEEEEEEEEEEEEEEEEEEEEEEEEEE░░░░E░E░EE 120 / 510 (23%)
EEEEEEEEE░E░░░EEE░EEEEEEEEEEEEE░EEEE░EEEEEEE░░░░E░░EEEEE░░EE 180 / 510 (35%)
░EEEE░░░E░E░EEEEEEEEEEEEEE░░░░░░░░░E░E░EE░░░░EEEEEEE░EEEEEEE 240 / 510 (47%)
EEEEEEEEEE░E░EEE░░░EEEEE░░░EEEE░░EE░░EEE░░░EEEEE░░E░EE░░░░EE 300 / 510 (58%)
░░EEEE░EEEEEEEEEEEEE░EEEE░E░E░EEEEEEEE░EEEEEEE░░░EEEEEEEEEEE 360 / 510 (70%)
░EE░░░E░░E░E░EE░░EEEEE░░░E░░░EEE░░EEEEEEEEE░EEE░EEEEEEEEEEE░ 420 / 510 (82%)
░░E░░░E░EE░░E░░EEEEEE░░E░E░E░░E░░░░░EEEE░EE░░EEEEE░░EE░EEEE░ 480 / 510 (94%)
EEEEEEEEEEEEEEEEE░EEEEEEEEEEEE

Detected level 6 as a suitable initial default
Config file created successfully. Please re-run psalm.
root@599da793f2ca:/var/www/sites/api-tp# php vendor/bin/psalm-plugin enable psalm/plugin-symfony


 [OK] Plugin enabled


root@599da793f2ca:/var/www/sites/api-tp#
```