### PR TITLE
Fixed tests to work with psalm5

### DIFF
--- a/tests/acceptance/acceptance/forms/AbstractTypeExtension.feature
+++ b/tests/acceptance/acceptance/forms/AbstractTypeExtension.feature
@@ -11,6 +11,9 @@ Feature: FormType templates
       use Symfony\Component\Form\AbstractTypeExtension;
       use Symfony\Component\Form\Extension\Core\Type\FormType;
 
+      /**
+       * @extends AbstractTypeExtension<string>
+       */
       class TestExtension extends AbstractTypeExtension
       {
           public static function getExtendedTypes(): iterable
@@ -30,6 +33,9 @@ Feature: FormType templates
       use Symfony\Component\Form\AbstractTypeExtension;
       use Symfony\Component\Form\Extension\Core\Type\FormType;
 
+      /**
+       * @extends AbstractTypeExtension<string>
+       */
       class TestExtension extends AbstractTypeExtension
       {
           public static function getExtendedTypes(): iterable


### PR DESCRIPTION
Added missing templates in tests that were working in psalm4, but not in psalm5.