### PR TITLE
Compatibility with Annotations 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "symfony/form": "^4.0 || ^5.0 || ^6.0",
-        "doctrine/annotations": "^1.8",
+        "doctrine/annotations": "^1.8|^2",
         "doctrine/orm": "^2.7",
         "phpunit/phpunit": "~7.5 || ~9.5",
         "symfony/cache-contracts": "^1.0 || ^2.0",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.7.3@38c452ae584467e939d55377aaf83b5a26f19dd1">
+  <file src="src/Plugin.php">
+    <UnusedPsalmSuppress occurrences="1">
+      <code>DeprecatedMethod</code>
+    </UnusedPsalmSuppress>
+  </file>
   <file src="src/Twig/Context.php">
     <UnnecessaryVarAnnotation occurrences="2">
       <code>int</code>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -54,8 +54,10 @@ class Plugin implements PluginEntryPointInterface
 
         if (class_exists(AnnotationRegistry::class)) {
             require_once __DIR__.'/Handler/DoctrineRepositoryHandler.php';
-            /** @psalm-suppress DeprecatedMethod */
-            AnnotationRegistry::registerLoader('class_exists');
+            if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
+                /** @psalm-suppress DeprecatedMethod */
+                AnnotationRegistry::registerLoader('class_exists');
+            }
             $api->registerHooksFromClass(DoctrineRepositoryHandler::class);
 
             require_once __DIR__.'/Handler/AnnotationHandler.php';


### PR DESCRIPTION
Running this plugin having Doctrine Annotations 2 installed currently results in a crash: https://github.com/doctrine/DoctrineBundle/actions/runs/3742592139/jobs/6353730157

The call to `AnnotationRegistry::registerLoader()` is safeguarded with a `method_exists()` call now. Alternatively, we could also declare a conflict with Annotations < 1.10 and remove the call entirely.