### PR TITLE
[v5.x] Fix console handler with named arguments and add more tests

### DIFF
--- a/src/Handler/ConsoleHandler.php
+++ b/src/Handler/ConsoleHandler.php
@@ -265,7 +265,7 @@ class ConsoleHandler implements AfterMethodCallAnalysisInterface
 
                 $key = array_search($name, $params);
                 Assert::integer($key);
-                $params = array_slice($params, $key + 1);
+                unset($params[$key]);
             } else {
                 $name = array_shift($params);
             }

--- a/tests/acceptance/acceptance/console/ConsoleArgumentNamedArgs.feature
+++ b/tests/acceptance/acceptance/console/ConsoleArgumentNamedArgs.feature
@@ -8,6 +8,7 @@ Feature: ConsoleArgument named arguments with PHP8
       <?php
 
       use Symfony\Component\Console\Command\Command;
+      use Symfony\Component\Console\Input\InputArgument;
       use Symfony\Component\Console\Input\InputInterface;
       use Symfony\Component\Console\Output\OutputInterface;
       """
@@ -20,6 +21,31 @@ Feature: ConsoleArgument named arguments with PHP8
         protected function configure(): void
         {
           $this->addArgument('test', default: 'test');
+        }
+
+        protected function execute(InputInterface $input, OutputInterface $output): int
+        {
+          /** @psalm-trace $argument */
+          $argument = $input->getArgument('test');
+
+          return 0;
+        }
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type  | Message           |
+      | Trace | $argument: string |
+    And I see no other errors
+
+  Scenario: Assert adding console argument with only named arguments works as expected
+    Given I have the following code
+      """
+      class MyCommand extends Command
+      {
+        protected function configure(): void
+        {
+          $this->addArgument(name: 'test', description: 'foo', mode: InputArgument::OPTIONAL, default: 'test');
         }
 
         protected function execute(InputInterface $input, OutputInterface $output): int

--- a/tests/acceptance/acceptance/console/ConsoleOptionNamedArgs.feature
+++ b/tests/acceptance/acceptance/console/ConsoleOptionNamedArgs.feature
@@ -37,3 +37,34 @@ Feature: ConsoleOption named arguments with PHP8
       | Type  | Message         |
       | Trace | $string: string |
     And I see no other errors
+
+  Scenario: Assert adding options with only named arguments works as expected
+    Given I have the following code
+      """
+      class MyCommand extends Command
+      {
+        public function configure(): void
+        {
+          $this->addOption(
+            name: 'test',
+            mode: InputOption::VALUE_REQUIRED,
+            description: 'foo',
+            shortcut: 't',
+            default: 'test'
+          );
+        }
+
+        public function execute(InputInterface $input, OutputInterface $output): int
+        {
+          /** @psalm-trace $string */
+          $string = $input->getOption('test');
+
+          return 0;
+        }
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type  | Message         |
+      | Trace | $string: string |
+    And I see no other errors


### PR DESCRIPTION
The plugin crashed when using arguments or options with named arguments. The existing tests weren't sufficient to trigger the problem so I wrote some that do.

This also applies to v4.x (see #300)