### PR TITLE
Extended `RequiredSetterHandler` to also check for attributes

### DIFF
--- a/src/Handler/RequiredSetterHandler.php
+++ b/src/Handler/RequiredSetterHandler.php
@@ -10,6 +10,7 @@ use PhpParser\NodeTraverser;
 use Psalm\Internal\PhpVisitor\AssignmentMapVisitor;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
+use Psalm\Storage\ClassLikeStorage;
 
 class RequiredSetterHandler implements AfterClassLikeVisitInterface
 {
@@ -18,32 +19,56 @@ class RequiredSetterHandler implements AfterClassLikeVisitInterface
         $stmt = $event->getStmt();
         $storage = $event->getStorage();
 
+        $stmt_source = $event->getStatementsSource();
+        $aliases = $stmt_source->getAliases();
+
         if (!$stmt instanceof Class_) {
             return;
         }
 
         foreach ($stmt->getMethods() as $method) {
+            // Check for PhpDoc annotation
             $docComment = $method->getDocComment();
-
             if ($docComment instanceof Doc && false !== strpos($docComment->getText(), '@required')) {
-                $traverser = new NodeTraverser();
-                $visitor = new AssignmentMapVisitor(null);
-                $traverser->addVisitor($visitor);
-                $traverser->traverse($method->getStmts() ?? []);
+                self::markAsInitializedProperties($storage, $method->getStmts() ?? []);
+            }
 
-                foreach (array_keys($visitor->getAssignmentMap()) as $assignment) {
-                    if (0 !== strpos($assignment, '$this->')) {
-                        continue;
+            // Check for attribute annotation
+            foreach ($method->getAttrGroups() as $attrGroup) {
+                foreach ($attrGroup->attrs as $attribute) {
+                    /** @var lowercase-string $lcName */
+                    $lcName = $attribute->name->toLowerString();
+                    if (array_key_exists($lcName, $aliases->uses)) {
+                        $name = $aliases->uses[$lcName];
+                    } else {
+                        $name = $attribute->name->toString();
                     }
-
-                    $property = substr($assignment, strlen('$this->'));
-                    if (!array_key_exists($property, $storage->properties)) {
-                        continue;
+                    if ('Symfony\Contracts\Service\Attribute\Required' === $name) {
+                        self::markAsInitializedProperties($storage, $method->getStmts() ?? []);
                     }
-
-                    $storage->initialized_properties[$property] = true;
                 }
             }
+        }
+    }
+
+    private static function markAsInitializedProperties(ClassLikeStorage $storage, array $stmts): void
+    {
+        $traverser = new NodeTraverser();
+        $visitor = new AssignmentMapVisitor(null);
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($stmts);
+
+        foreach (array_keys($visitor->getAssignmentMap()) as $assignment) {
+            if (0 !== strpos($assignment, '$this->')) {
+                continue;
+            }
+
+            $property = substr($assignment, strlen('$this->'));
+            if (!array_key_exists($property, $storage->properties)) {
+                continue;
+            }
+
+            $storage->initialized_properties[$property] = true;
         }
     }
 }

--- a/tests/acceptance/acceptance/RequiredSetter.feature
+++ b/tests/acceptance/acceptance/RequiredSetter.feature
@@ -44,3 +44,44 @@ Feature: Annotation class
       | Type                        | Message                                                                                                                           |
       | PropertyNotSetInConstructor | Property MyServiceB::$a is not defined in constructor of MyServiceB or in any private or final methods called in the constructor |
     And I see no other errors
+
+  Scenario: PropertyNotSetInConstructor error is not raised when the required attribute is present (with use).
+    Given I have the following code
+      """
+      <?php
+
+      use \Symfony\Contracts\Service\Attribute\Required;
+
+      final class MyServiceA {
+      }
+
+      final class MyServiceB {
+          private MyServiceA $a;
+          public function __construct(){}
+
+          #[Required]
+          private function setMyServiceA(MyServiceA $a): void { $this->a = $a; }
+      }
+      """
+    When I run Psalm
+    Then I see no errors
+
+
+  Scenario: PropertyNotSetInConstructor error is not raised when the required attribute is present (without use).
+    Given I have the following code
+      """
+      <?php
+
+      final class MyServiceA {
+      }
+
+      final class MyServiceB {
+          private MyServiceA $a;
+          public function __construct(){}
+
+          #[\Symfony\Contracts\Service\Attribute\Required]
+          private function setMyServiceA(MyServiceA $a): void { $this->a = $a; }
+      }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
Symfonys autowiring feature can be used [with attributes](https://symfony.com/doc/current/service_container/autowiring.html#autowiring-other-methods-e-g-setters-and-public-typed-properties) in comparison to PhpDoc, therefore the `RequiredSetterHandler` handler should check for that alternative too.