### PR TITLE
Fix outdated Twig Analyzer configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ To leverage the real Twig file analyzer, you have to configure a checker for the
 ```xml
 <fileExtensions>
    <extension name=".php" />
-   <extension name=".twig" checker="./vendor/psalm/plugin-symfony/src/Twig/TemplateFileAnalyzer.php"/>
+   <extension name=".twig" checker="/vendor/psalm/plugin-symfony/src/Twig/TemplateFileAnalyzer.php"/>
 </fileExtensions>
 ```
 


### PR DESCRIPTION
Sometime in the last few version, psalm changed how it reads paths from file extensions checkers, so using the Twig Analyzer checker as written in the docs fails with
```
Problem parsing /workspaces/myapp/psalm.xml:
  Error parsing config: cannot find file /workspaces/myapp./vendor/psalm/plugin-symfony/src/Twig/TemplateFileAnalyzer.php
```
Note the . in the path. This PR fixes the docs so it works as expected.