### PR TITLE
[console] Add 'suggestedValues' Parameter

### DIFF
--- a/src/Handler/ConsoleHandler.php
+++ b/src/Handler/ConsoleHandler.php
@@ -237,7 +237,7 @@ class ConsoleHandler implements AfterMethodCallAnalysisInterface
      */
     private static function normalizeOptionParams(array $args): array
     {
-        return self::normalizeParams(['name', 'shortcut', 'mode', 'description', 'default'], $args);
+        return self::normalizeParams(['name', 'shortcut', 'mode', 'description', 'default', 'suggestedValues'], $args);
     }
 
     /**
@@ -247,7 +247,7 @@ class ConsoleHandler implements AfterMethodCallAnalysisInterface
      */
     private static function normalizeArgumentParams(array $args): array
     {
-        return self::normalizeParams(['name', 'mode', 'description', 'default'], $args);
+        return self::normalizeParams(['name', 'mode', 'description', 'default', 'suggestedValues'], $args);
     }
 
     private static function normalizeParams(array $params, array $args): array


### PR DESCRIPTION
I was facing the issue described in #232.

In my case the given Argument Names are not in the Console Handler, after adding them, plugin runs fine.



```php
    protected function configure(): void {
        $this
            ->addArgument(
                'report_id',
                InputArgument::REQUIRED,
                'The Report id to invoke.'
            )
            ->addArgument(
                'query',
                InputArgument::OPTIONAL,
                'The url encoded values for the report.'
            )
            ->addArgument(
                'format',
                InputArgument::OPTIONAL,
                'The format to use',
                default: FileFormatEnum::EXCEL->name,
                suggestedValues: [
                    FileFormatEnum::PDF->name,
                    FileFormatEnum::EXCEL->name,
                    FileFormatEnum::CSV->name,
                ],
            )
            ->addArgument(
                'country',
                InputArgument::OPTIONAL,
                'The country id',
                default: 'DEFAULT',
                suggestedValues: self::COUNTRIES,
            );
    }
```