### PR TITLE
Allow setting Symfony's version explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ If you're getting the following error
 </issueHandlers>
 ```
 
+#### Symfony version
+
+By default, the plugin uses the `Kernel::MAJOR_VERSION` constant to determine your version of Symfony. However, this
+might not be accurate if you have Psalm installed globally. You can set the version explicitly using
+the `symfonyMajorVersion` configuration option:
+
+```xml
+<pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin">
+    <symfonyMajorVersion>6</symfonyMajorVersion>
+</pluginClass>
+```
+
 ### Twig tainting (experimental)
 
 When it comes to taint analysis for Twig templates, there are currently two approaches:

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -89,7 +89,7 @@ class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(ContainerHandler::class);
 
         $this->addStubs($registration, __DIR__.'/Stubs/common');
-        $this->addStubs($registration, __DIR__.'/Stubs/'.Kernel::MAJOR_VERSION);
+        $this->addStubs($registration, __DIR__.'/Stubs/'.($config->symfonyMajorVersion ?? Kernel::MAJOR_VERSION));
         $this->addStubs($registration, __DIR__.'/Stubs/php');
 
         if (isset($config->twigCachePath)) {


### PR DESCRIPTION
I have Psalm installed globally and use it for different projects, each with different versions of Symfony. One problem I'm facing is that the plugin determines the version of Symfony by using the `Kernel::MAJOR_VERSION` constant, which means it will always use the globally installed version. As a result, it might not use the correct stubs for the specific version needed.

The same issue occurs when using the [composer-bin-plugin](https://github.com/bamarni/composer-bin-plugin). This PR allows configuring the version explicitly in the XML file:

```xml
<pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin">
    <symfonyMajorVersion>6</symfonyMajorVersion>
</pluginClass>
```