### PR TITLE
Add stubs for Symfony 7

### DIFF
--- a/src/Stubs/7/Bundle/FrameworkBundle/Controller/AbstractController.stubphp
+++ b/src/Stubs/7/Bundle/FrameworkBundle/Controller/AbstractController.stubphp
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Controller;
+
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
+
+abstract class AbstractController implements ServiceSubscriberInterface
+{
+    /**
+     * @var ContainerInterface
+     * @psalm-suppress PropertyNotSetInConstructor
+     */
+    protected $container;
+
+    /**
+     * @template TData
+     * @template TFormType of FormTypeInterface<TData>
+     *
+     * @psalm-param class-string<TFormType> $type
+     *
+     * @psalm-return FormInterface<TData>
+     */
+    protected function createForm(string $type, $data = null, array $options = []): FormInterface {}
+}

--- a/src/Stubs/7/Bundle/FrameworkBundle/Controller/AbstractController.stubphp
+++ b/src/Stubs/7/Bundle/FrameworkBundle/Controller/AbstractController.stubphp
@@ -10,10 +10,9 @@ use Symfony\Component\Form\FormTypeInterface;
 abstract class AbstractController implements ServiceSubscriberInterface
 {
     /**
-     * @var ContainerInterface
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    protected $container;
+    protected ContainerInterface $container;
 
     /**
      * @template TData
@@ -23,5 +22,5 @@ abstract class AbstractController implements ServiceSubscriberInterface
      *
      * @psalm-return FormInterface<TData>
      */
-    protected function createForm(string $type, $data = null, array $options = []): FormInterface {}
+    protected function createForm(string $type, mixed $data = null, array $options = []): FormInterface {}
 }

--- a/src/Stubs/7/Component/HttpFoundation/InputBag.stubphp
+++ b/src/Stubs/7/Component/HttpFoundation/InputBag.stubphp
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * @template T of string|int|float|bool
+ */
+final class InputBag extends ParameterBag
+{
+    /**
+     * Returns a string input value by name.
+     *
+     * @template D of T|null
+     * @psalm-param D $default
+     * @psalm-return D|T
+     * @psalm-taint-source input
+     * @psalm-mutation-free
+     */
+    public function get(string $key, $default = null) {}
+
+    /**
+     * Returns the parameters.
+     *
+     * @param string|null $key The name of the parameter to return or null to get them all
+     *
+     * @return array An array of parameters
+     *
+     * @psalm-taint-source input
+     * @psalm-mutation-free
+     */
+    public function all(string $key = null) {}
+}

--- a/src/Stubs/7/Component/HttpFoundation/InputBag.stubphp
+++ b/src/Stubs/7/Component/HttpFoundation/InputBag.stubphp
@@ -16,7 +16,7 @@ final class InputBag extends ParameterBag
      * @psalm-taint-source input
      * @psalm-mutation-free
      */
-    public function get(string $key, $default = null) {}
+    public function get(string $key, mixed $default = null): string|int|float|bool|null {}
 
     /**
      * Returns the parameters.
@@ -28,5 +28,5 @@ final class InputBag extends ParameterBag
      * @psalm-taint-source input
      * @psalm-mutation-free
      */
-    public function all(string $key = null) {}
+    public function all(?string $key = null): array {}
 }

--- a/src/Stubs/7/Component/HttpFoundation/ParameterBag.stubphp
+++ b/src/Stubs/7/Component/HttpFoundation/ParameterBag.stubphp
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+class ParameterBag implements \IteratorAggregate, \Countable
+{
+    /**
+     * Returns a parameter by name.
+     *
+     * @param string $key     The key
+     * @param mixed  $default The default value if the parameter key does not exist
+     *
+     * @return mixed
+     * @psalm-taint-source input
+     * @psalm-mutation-free
+     */
+    public function get(string $key, $default = null) {}
+
+    /**
+     * Returns the parameters.
+     *
+     * @param string|null $key The name of the parameter to return or null to get them all
+     *
+     * @return array An array of parameters
+     *
+     * @psalm-taint-source input
+     * @psalm-mutation-free
+     */
+    public function all(string $key = null) {}
+}

--- a/src/Stubs/7/Component/HttpFoundation/ParameterBag.stubphp
+++ b/src/Stubs/7/Component/HttpFoundation/ParameterBag.stubphp
@@ -14,7 +14,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      * @psalm-taint-source input
      * @psalm-mutation-free
      */
-    public function get(string $key, $default = null) {}
+    public function get(string $key, mixed $default = null): mixed {}
 
     /**
      * Returns the parameters.
@@ -26,5 +26,5 @@ class ParameterBag implements \IteratorAggregate, \Countable
      * @psalm-taint-source input
      * @psalm-mutation-free
      */
-    public function all(string $key = null) {}
+    public function all(?string $key = null): array {}
 }

--- a/src/Stubs/7/Component/HttpFoundation/Request.stubphp
+++ b/src/Stubs/7/Component/HttpFoundation/Request.stubphp
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+class Request
+{
+    /**
+     * @psalm-var InputBag
+     */
+    public $request;
+
+    /**
+     * @psalm-var InputBag<string>
+     */
+    public $query;
+
+    /**
+     * @psalm-var InputBag<string>
+     */
+    public $cookies;
+}

--- a/src/Stubs/7/Component/HttpFoundation/Request.stubphp
+++ b/src/Stubs/7/Component/HttpFoundation/Request.stubphp
@@ -7,15 +7,15 @@ class Request
     /**
      * @psalm-var InputBag
      */
-    public $request;
+    public InputBag $request;
 
     /**
      * @psalm-var InputBag<string>
      */
-    public $query;
+    public InputBag $query;
 
     /**
      * @psalm-var InputBag<string>
      */
-    public $cookies;
+    public InputBag $cookies;
 }

--- a/src/Stubs/7/Component/Serializer/Normalizer/DenormalizerInterface.stubphp
+++ b/src/Stubs/7/Component/Serializer/Normalizer/DenormalizerInterface.stubphp
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+interface DenormalizerInterface
+{
+    /**
+     * @template TObject of object
+     * @template TType of string|class-string<TObject>
+     *
+     * @psalm-param TType $type
+     * @psalm-return (TType is class-string<TObject> ? TObject : mixed)
+     */
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = []);
+}

--- a/src/Stubs/7/Component/Serializer/Normalizer/DenormalizerInterface.stubphp
+++ b/src/Stubs/7/Component/Serializer/Normalizer/DenormalizerInterface.stubphp
@@ -11,5 +11,5 @@ interface DenormalizerInterface
      * @psalm-param TType $type
      * @psalm-return (TType is class-string<TObject> ? TObject : mixed)
      */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []);
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed;
 }


### PR DESCRIPTION
Currently there are no stubs for Symfony v7, closes #347.

I'm not exactly sure what needs to be done here, or if anything needs to be done at all. I've split the PR into two commits. In the first commit, I copied the stubs from v7. In the second, I synced the code with what is in Symfony. I'm not sure if this is actually necessary. I also checked if there have been any updates to the docblocks for these functions, but as far as I could tell, nothing has changed.