### PR TITLE
Update composer.json to support Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.1",
         "ext-simplexml": "*",
-        "symfony/framework-bundle": "^5.0 || ^6.0 || ^7.0",
+        "symfony/framework-bundle": "^5.0 || ^6.0 || ^7.0 || ^8.0",
         "vimeo/psalm": "^6 || dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
In composer.json most symfony dependencies have been updated to support version 8 but the framework bundle was still limited to 7