### PR TITLE
Update type information for InputBag::get() to symfony 7.4 / 8.0

### DIFF
--- a/src/Stubs/7/Component/HttpFoundation/InputBag.stubphp
+++ b/src/Stubs/7/Component/HttpFoundation/InputBag.stubphp
@@ -3,16 +3,19 @@
 namespace Symfony\Component\HttpFoundation;
 
 /**
- * @template T of string|int|float|bool
+ * @template TInput of string|int|float|bool|null
  */
 final class InputBag extends ParameterBag
 {
     /**
-     * Returns a string input value by name.
+     * Returns a scalar input value by name.
      *
-     * @template D of T|null
-     * @psalm-param D $default
-     * @psalm-return D|T
+     * @template TDefault of string|int|float|bool|null
+     *
+     * @param TDefault $default The default value if the input key does not exist
+     *
+     * @return TDefault|TInput
+     *
      * @psalm-taint-source input
      * @psalm-mutation-free
      */


### PR DESCRIPTION
The type information was outdated since symfony 7.4 / 8.0. I have copied the new docblock as provided in https://github.com/symfony/http-foundation/commit/3eef5d4f9f376fd3e748650ad9cd11cb593a68d3.

Otherwise it caused false `InvalidArgument` errors on calls like `Request::$query->get('abc', true)` where the parameter `$default` did not match the input type.