### PR TITLE
add symfony 8 in CI pipeline

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -88,6 +88,10 @@ jobs:
             symfony-version: 7.4
           - php-version: 8.1
             symfony-version: 8.0
+          - php-version: 8.2
+            symfony-version: 8.0
+          - php-version: 8.3
+            symfony-version: 8.0
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -79,12 +79,15 @@ jobs:
           - 6
           - 7.0
           - 7.4
+          - 8.0
 
         exclude:
           - php-version: 8.1
             symfony-version: 7.0
           - php-version: 8.1
             symfony-version: 7.4
+          - php-version: 8.1
+            symfony-version: 8.0
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.8|^2",
-        "doctrine/orm": "^2.9",
+        "doctrine/orm": "^2.9 || ^3.6",
         "phpunit/phpunit": "~7.5 || ~9.5",
         "symfony/cache-contracts": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "*",

--- a/tests/fixture/Doctrine/Foo.php
+++ b/tests/fixture/Doctrine/Foo.php
@@ -6,9 +6,7 @@ namespace Psalm\SymfonyPsalmPlugin\Tests\Fixture\Doctrine;
 
 use Doctrine\ORM\Mapping\Entity;
 
-/**
- * @Entity(repositoryClass=FooRepository::class)
- */
+#[Entity(repositoryClass: FooRepository::class)]
 class Foo
 {
 }


### PR DESCRIPTION
Added symfony 8 in CI pipeline
Symfony 8 [requires php 8.4 or higher](https://symfony.com/releases/8.0), that is why all earlier php versions are excluded