### PR TITLE
Improve dead-code detection by skipping excluded services

### DIFF
--- a/src/Handler/ContainerHandler.php
+++ b/src/Handler/ContainerHandler.php
@@ -6,7 +6,9 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
+use Psalm\Codebase;
 use Psalm\CodeLocation;
+use Psalm\Internal\MethodIdentifier;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
@@ -20,9 +22,14 @@ use Psalm\SymfonyPsalmPlugin\Issue\NamingConventionViolation;
 use Psalm\SymfonyPsalmPlugin\Issue\PrivateService;
 use Psalm\SymfonyPsalmPlugin\Issue\ServiceNotFound;
 use Psalm\SymfonyPsalmPlugin\Symfony\ContainerMeta;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\SerializerInterface;
 
 final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterClassLikeVisitInterface, AfterCodebasePopulatedInterface, BeforeAddIssueInterface
 {
@@ -68,6 +75,7 @@ final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterC
         if (!$firstArg instanceof Arg) {
             return;
         }
+        $secondArg = $expr->args[1] ?? null;
 
         if (!self::isContainerMethod($declaring_method_id, 'get')) {
             if (self::isContainerMethod($declaring_method_id, 'getparameter')) {
@@ -78,6 +86,13 @@ final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterC
                         $statements_source->getSuppressedIssues()
                     );
                 }
+            }
+
+            // when calling `$denormalizer->denormalize([], Foo::class)` mark constructor of Foo as used
+            if (self::isDenormalizerMethod($declaring_method_id) && $secondArg instanceof Arg && ($value = $secondArg->value) instanceof ClassConstFetch) {
+                $className = $value->class->getAttribute('resolvedName');
+                $visited = [];
+                self::markConstructorChainAsUsed($className, $codebase, $declaring_method_id, $visited);
             }
 
             return;
@@ -235,5 +250,80 @@ final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterC
     private static function followsNamingConvention(string $name): bool
     {
         return !preg_match('/[A-Z]/', $name);
+    }
+
+    private static function isDenormalizerMethod(string $methodName): bool
+    {
+        if (!str_starts_with($methodName, 'Symfony\Component\Serializer\\')) {
+            return false;
+        }
+
+        return str_ends_with($methodName, 'denormalize') || str_ends_with($methodName, 'deserialize');
+    }
+
+    /**
+     * Marks the constructor of $className as used, then recurses into all
+     * property types to mark their constructors as used too. This is needed
+     * because Symfony's Serializer constructs the full object graph at
+     * runtime without any static instantiation in PHP code.
+     *
+     * @param array<string, true> $visited guard against circular references
+     */
+    private static function markConstructorChainAsUsed(string $className, Codebase $codebase, string $callingMethodId, array &$visited): void
+    {
+        if (isset($visited[$className])) {
+            return;
+        }
+        $visited[$className] = true;
+
+        $codebase->methodExists(new MethodIdentifier($className, '__construct'), null, $callingMethodId);
+
+        if (!$codebase->classlike_storage_provider->has($className)) {
+            return;
+        }
+
+        $classStorage = $codebase->classlike_storage_provider->get($className);
+
+        foreach ($classStorage->properties as $propertyStorage) {
+            $type = $propertyStorage->type ?? $propertyStorage->signature_type;
+            if (null === $type) {
+                continue;
+            }
+            foreach (self::extractNamedObjectClassNames($type) as $nestedClassName) {
+                self::markConstructorChainAsUsed($nestedClassName, $codebase, $callingMethodId, $visited);
+            }
+        }
+    }
+
+    /**
+     * Recursively extracts fully-qualified class names from a Union type,
+     * unwrapping array containers (SubObject[], array<K,V>, list<SubObject>)
+     * so that collection-typed properties are also followed.
+     *
+     * @return list<string>
+     */
+    private static function extractNamedObjectClassNames(Union $type): array
+    {
+        $classNames = [];
+        foreach ($type->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNamedObject) {
+                $classNames[] = $atomic->value;
+            } elseif ($atomic instanceof TKeyedArray) {
+                // covers list<SubObject>, non-empty-list<SubObject>, and array{key: SubObject}
+                // for list<T>, properties[0] already holds T (same as fallback_params[1])
+                foreach ($atomic->properties as $propType) {
+                    foreach (self::extractNamedObjectClassNames($propType) as $name) {
+                        $classNames[] = $name;
+                    }
+                }
+            } elseif ($atomic instanceof TArray) {
+                // covers SubObject[] (array<array-key, SubObject>) and TNonEmptyArray
+                foreach (self::extractNamedObjectClassNames($atomic->type_params[1]) as $name) {
+                    $classNames[] = $name;
+                }
+            }
+        }
+
+        return $classNames;
     }
 }

--- a/src/Symfony/ContainerMeta.php
+++ b/src/Symfony/ContainerMeta.php
@@ -138,6 +138,10 @@ final class ContainerMeta
                 continue;
             }
 
+            if ($definition->hasTag('container.excluded')) {
+                continue;
+            }
+
             $definitionFactory = $definition->getFactory();
             if ($definition->hasTag('container.service_locator_context') && is_array($definitionFactory)) {
                 /** @var Reference $reference */

--- a/tests/acceptance/acceptance/DenormalizerInterface.feature
+++ b/tests/acceptance/acceptance/DenormalizerInterface.feature
@@ -43,6 +43,123 @@ Feature: Denormalizer interface
       | Trace                  | $result: mixed                                                 |
     And I see no other errors
 
+  Scenario: Constructor of denormalized top-level class is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Address {
+        public function __construct(public string $street) {}
+      }
+
+      function test(DenormalizerInterface $denormalizer): void
+      {
+        $denormalizer->denormalize([], Address::class);
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Constructor of typed sub-property is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Street {
+        public function __construct(public string $name) {}
+      }
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Address {
+        public function __construct(public Street $street) {}
+      }
+
+      function test(DenormalizerInterface $denormalizer): void
+      {
+        $denormalizer->denormalize([], Address::class);
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Constructor of array-collection sub-object is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Tag {
+        public function __construct(public string $name) {}
+      }
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Post {
+        /** @var Tag[] */
+        public array $tags = [];
+        public function __construct(public string $title) {}
+      }
+
+      function test(DenormalizerInterface $denormalizer): void
+      {
+        $denormalizer->denormalize([], Post::class);
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Constructor of list sub-object is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Tag {
+        public function __construct(public string $name) {}
+      }
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Post {
+        /** @var list<Tag> */
+        public array $tags = [];
+        public function __construct(public string $title) {}
+      }
+
+      function test(DenormalizerInterface $denormalizer): void
+      {
+        $denormalizer->denormalize([], Post::class);
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Circular object graph does not cause infinite recursion
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Node {
+        public ?Node $parent = null;
+        public function __construct(public string $value) {}
+      }
+
+      function test(DenormalizerInterface $denormalizer): void
+      {
+        $denormalizer->denormalize([], Node::class);
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
   Scenario: Psalm does not complain about the missing $data parameter type in the denormalizer implementation
     Given I have the following code
       """

--- a/tests/acceptance/container.xml
+++ b/tests/acceptance/container.xml
@@ -100,5 +100,12 @@
       <argument type="service" id="service_container"/>
       <factory service=".service_locator.890xyz" method="withContext"/>
     </service>
+    <!-- excluded services still present in debug container -->
+    <service id=".abstract.App\FooInterface" class="App\FooInterface" autowire="true" autoconfigure="true" abstract="true">
+      <tag name="container.excluded" source="because the class is abstract"/>
+    </service>
+    <service id="App\Exception\FooException" class="App\Exception\FooException" abstract="true">
+      <tag name="container.excluded" source="in &quot;config/services.php&quot;"/>
+    </service>
   </services>
 </container>

--- a/tests/unit/Symfony/ContainerMetaTest.php
+++ b/tests/unit/Symfony/ContainerMetaTest.php
@@ -66,6 +66,14 @@ class ContainerMetaTest extends TestCase
         ];
     }
 
+    public function testGetClassesDoesNotContainExcludedServices(): void
+    {
+        $classNames = $this->containerMeta->getClassNames();
+
+        $this->assertNotContains('App\Exception\FooException', $classNames);
+        $this->assertNotContains('App\FooInterface', $classNames);
+    }
+
     /**
      * @testdox with non-existent xml file
      */


### PR DESCRIPTION
I stumbled upon some dead code and was wondering why it was not flagged as such. The current solution to suppress `UnusedClass` for all container services works fine to suppress quite a few false positives, but effectively bypasses dead code dection.

Assuming this is pretty much the setup most people use:
```php
return App::config([
    'services' => [
        'App\\' => [
            'resource' => '../src/',
            'exclude' => [
                '../src/SomeDirectory/*'
            ]
        ],
    ],
]);
```
I feel like most projects rely on loading their root folder. This declares every class in `src/` as a service in the debug container. And as `UnusedClass` is a parent issue to `PossiblyUnusedMethod`, methods without a caller will also no longer be flagged.
This is simply reproducible with a skeleton Symfony project and some intentionally dead code.

As a first improvement I would like to propose excluding `excluded` services. In the example above, classes under `src/SomeDirectory/` will end up in the debug container as a service with the tag `container.excluded`. Which makes them not auto-wirable. So we shouldn't suppress `UnusedClass` nor `PossiblyUnusedMethod` for their constructors, as the container will never instantiate these classes.

A very typical example of excluded classes are things like value objects that are instantiated by the Serializer component. So I added a solution to find any calls to the Serializer's `denormalize` and `deserialize` methods to treat the target class constructor and its sub-properties as used.

I can't be certain that this catches every false-positive that surfaces after this change, but I am happy to work on further improvements.
I tested this version on a relatively basic demo project and a large code base, where I was able to find quite a bit of dead-code without introducing false-positives.

This still does not solve the issue of actual unused services. The debug container does not optimise defintions, so it contains even unused services. Again also bypassing the unused method check for these services, as the parent `UnusedClass` is already suppressed. But I would argue that this should be tackled separately. Will open an issue to discuss potential solutions.

This does not re-introduce the original issue fixed by #325 

P.S. thanks for this great plugin! It's basically a must for Symfony projects with Psalm