### PR TITLE
Improve unused code detection by adding class / method references from Symfony compnents

### DIFF
--- a/src/Handler/ContainerHandler.php
+++ b/src/Handler/ContainerHandler.php
@@ -6,25 +6,34 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
+use Psalm\Codebase;
 use Psalm\CodeLocation;
+use Psalm\Internal\MethodIdentifier;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
 use Psalm\Plugin\EventHandler\AfterMethodCallAnalysisInterface;
-use Psalm\Plugin\EventHandler\BeforeAddIssueInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
 use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
 use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
-use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
 use Psalm\SymfonyPsalmPlugin\Issue\NamingConventionViolation;
 use Psalm\SymfonyPsalmPlugin\Issue\PrivateService;
 use Psalm\SymfonyPsalmPlugin\Issue\ServiceNotFound;
 use Psalm\SymfonyPsalmPlugin\Symfony\ContainerMeta;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\Serializer;
 
-final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterClassLikeVisitInterface, AfterCodebasePopulatedInterface, BeforeAddIssueInterface
+final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterClassLikeVisitInterface, AfterCodebasePopulatedInterface
 {
     private const GET_CLASSLIKES = [
         'Psr\Container\ContainerInterface',
@@ -35,20 +44,46 @@ final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterC
         'Symfony\Bundle\FrameworkBundle\Test\TestContainer',
     ];
 
+    /** @var array<class-string, string> */
+    private const INVOKABLE_CLASS_ATTRIBUTES = [
+        AsController::class => 'Symfony\Component\HttpKernel\Kernel::handle',
+    ];
+
+    /** @var array<string, string> */
+    private const CALLABLE_METHOD_ATTRIBUTES = [
+        Route::class => 'Symfony\Component\HttpKernel\Kernel::handle',
+        'Symfony\Component\Validator\Constraints\Callback' => 'Symfony\Component\Validator\Validator\TraceableValidator::validate',
+        'Doctrine\ORM\Mapping\PrePersist' => 'Doctrine\ORM\EntityManager::flush',
+        'Doctrine\ORM\Mapping\PostPersist' => 'Doctrine\ORM\EntityManager::flush',
+        'Doctrine\ORM\Mapping\PreUpdate' => 'Doctrine\ORM\EntityManager::flush',
+        'Doctrine\ORM\Mapping\PostUpdate' => 'Doctrine\ORM\EntityManager::flush',
+        'Doctrine\ORM\Mapping\PreRemove' => 'Doctrine\ORM\EntityManager::flush',
+        'Doctrine\ORM\Mapping\PostRemove' => 'Doctrine\ORM\EntityManager::flush',
+        'Doctrine\ORM\Mapping\PostLoad' => 'Doctrine\ORM\EntityManager::flush',
+        'Doctrine\ORM\Mapping\PreFlush' => 'Doctrine\ORM\EntityManager::flush',
+    ];
+
+    /** @var array<string, string> */
+    private const MAP_PAYLOAD_ATTRIBUTES = [
+        'Symfony\Component\HttpKernel\Attribute\MapQueryString' => 'Symfony\Component\HttpKernel\Kernel::handle',
+        'Symfony\Component\HttpKernel\Attribute\MapRequestPayload' => 'Symfony\Component\HttpKernel\Kernel::handle',
+    ];
+
+    /** @var array<string, string> */
+    private const CALLABLE_TAGS = [
+        'kernel.event_listener' => 'Symfony\Component\EventDispatcher\EventDispatcher::dispatch',
+        'messenger.message_handler' => 'Symfony\Component\Messenger\Middleware\HandleMessageMiddleware::handle',
+        'doctrine.orm.entity_listener' => 'Doctrine\ORM\Event\ListenersInvoker::invoke',
+    ];
+
     private static ?ContainerMeta $containerMeta = null;
 
-    /**
-     * @var array<string> collection of cower-cased class names that are present in the container
-     */
-    private static array $containerClassNames = [];
+    /** @var array<string, true> */
+    private static array $markedDtoConstructors = [];
 
     public static function init(ContainerMeta $containerMeta): void
     {
         self::$containerMeta = $containerMeta;
-
-        self::$containerClassNames = array_map(function (string $className): string {
-            return strtolower($className);
-        }, self::$containerMeta->getClassNames());
     }
 
     #[\Override]
@@ -68,6 +103,7 @@ final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterC
         if (!$firstArg instanceof Arg) {
             return;
         }
+        $secondArg = $expr->args[1] ?? null;
 
         if (!self::isContainerMethod($declaring_method_id, 'get')) {
             if (self::isContainerMethod($declaring_method_id, 'getparameter')) {
@@ -78,6 +114,13 @@ final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterC
                         $statements_source->getSuppressedIssues()
                     );
                 }
+            }
+
+            // when calling e.g. `$denormalizer->denormalize([], Foo::class)` mark constructor of Foo and sub-objects as used
+            if (self::isDenormalizerMethod($declaring_method_id) && $secondArg instanceof Arg && ($value = $secondArg->value) instanceof ClassConstFetch) {
+                $className = $value->class->getAttribute('resolvedName');
+                $visited = [];
+                self::markConstructorChainAsUsed($className, $codebase, $declaring_method_id, $visited);
             }
 
             return;
@@ -162,17 +205,78 @@ final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterC
     public static function afterClassLikeVisit(AfterClassLikeVisitEvent $event): void
     {
         $codebase = $event->getCodebase();
-        $statements_source = $event->getStatementsSource();
         $storage = $event->getStorage();
 
-        $fileStorage = $codebase->file_storage_provider->get($statements_source->getFilePath());
-
-        if (\in_array($storage->name, ContainerHandler::GET_CLASSLIKES)) {
-            if (self::$containerMeta) {
-                foreach (self::$containerMeta->getClassNames() as $className) {
-                    $codebase->queueClassLikeForScanning($className);
-                    $fileStorage->referenced_classlikes[strtolower($className)] = $className;
+        // When parameter has mapping attribute (#[MapRequestPayload]), map class target and sub-objects as used
+        foreach ($storage->methods as $method) {
+            foreach ($method->params as $param) {
+                foreach ($param->attributes as $attribute) {
+                    $mapCaller = self::MAP_PAYLOAD_ATTRIBUTES[$attribute->fq_class_name] ?? null;
+                    if (null === $mapCaller) {
+                        continue;
+                    }
+                    $type = $param->signature_type ?? $param->type;
+                    if (null === $type) {
+                        continue;
+                    }
+                    foreach (self::extractNamedObjectClassNames($type) as $className) {
+                        self::markConstructorChainAsUsed($className, $codebase, $mapCaller, self::$markedDtoConstructors);
+                    }
                 }
+            }
+        }
+
+        // Mark invokable classes (e.g. #[AsController]) as used.
+        foreach (self::INVOKABLE_CLASS_ATTRIBUTES as $attributeClass => $callerIdentifier) {
+            if ($storage->hasAttributeIncludingParents($attributeClass, $codebase)) {
+                $identifier = new MethodIdentifier($storage->name, '__invoke');
+                $codebase->methodExists($identifier, null, $callerIdentifier);
+            }
+        }
+
+        // Mark EventSubscriber methods as used.
+        $dispatchCaller = new MethodIdentifier(EventDispatcher::class, 'dispatch');
+        if (is_subclass_of($class = $storage->name, EventSubscriberInterface::class) && method_exists($class, 'getSubscribedEvents')) {
+            foreach ($class::getSubscribedEvents() as $params) {
+                if (\is_string($params)) {
+                    $codebase->methodExists($class.'::'.$params, null, $dispatchCaller);
+                } elseif (isset($params[0]) && \is_string($params[0])) {
+                    $codebase->methodExists($class.'::'.$params[0], null, $dispatchCaller);
+                } else {
+                    foreach ($params as $listener) {
+                        if (!isset($listener[0])) {
+                            continue;
+                        }
+                        $codebase->methodExists($class.'::'.$listener[0], null, $dispatchCaller);
+                    }
+                }
+            }
+        }
+
+        // map methods as used with certain attributes (e.g. #[Route])
+        foreach ($storage->methods as $method) {
+            if (null === $method->cased_name) {
+                continue;
+            }
+            foreach ($method->attributes as $attribute) {
+                $callerIdentifier = self::CALLABLE_METHOD_ATTRIBUTES[$attribute->fq_class_name] ?? null;
+                if (null === $callerIdentifier) {
+                    continue;
+                }
+                $codebase->methodExists($storage->name.'::'.$method->cased_name, null, $callerIdentifier);
+            }
+        }
+
+        if (!self::$containerMeta instanceof ContainerMeta) {
+            return;
+        }
+
+        $fileStorage = $codebase->file_storage_provider->get($event->getStatementsSource()->getFilePath());
+
+        if (\in_array($storage->name, self::GET_CLASSLIKES)) {
+            foreach (self::$containerMeta->getClassNames() as $className) {
+                $codebase->queueClassLikeForScanning($className);
+                $fileStorage->referenced_classlikes[strtolower($className)] = $className;
             }
         }
     }
@@ -184,26 +288,56 @@ final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterC
             return;
         }
 
-        foreach ($event->getCodebase()->classlike_storage_provider->getAll() as $name => $storage) {
-            if (in_array($name, self::$containerClassNames, true)) {
-                $storage->suppressed_issues[] = 'UnusedClass';
+        // mark constructors of all services as used
+        $callerIdentifier = new MethodIdentifier(Container::class, 'get');
+        foreach (self::$containerMeta->getDefinitions() as $definition) {
+            if ($definition->hasTag('container.excluded')) {
+                continue;
+            }
+            if (null === $class = $definition->getClass()) {
+                continue;
+            }
+            $event->getCodebase()->file_reference_provider->addMethodReferenceToClass((string) $callerIdentifier, \strtolower($class));
+            $identifier = new MethodIdentifier($class, '__construct');
+            $event->getCodebase()->methodExists($identifier, null, $callerIdentifier);
+            foreach ($definition->getMethodCalls() as $methodCall) {
+                if (is_array($methodCall) && isset($methodCall[0]) && is_string($methodCall[0])) {
+                    $identifier = new MethodIdentifier($class, \strtolower($methodCall[0]));
+                    $event->getCodebase()->methodExists($identifier, null, $callerIdentifier);
+                }
             }
         }
-    }
 
-    #[\Override]
-    public static function beforeAddIssue(BeforeAddIssueEvent $event): ?bool
-    {
-        $data = $event->getIssue()->toIssueData('error');
-        if ('PossiblyUnusedMethod' === $data->type
-            && '__construct' === $data->selected_text
-            && null !== $data->dupe_key
-            && in_array(preg_replace('/::__construct$/', '', $data->dupe_key), self::$containerClassNames, true)) {
-            // Don't report service constructors as PossiblyUnusedMethod
-            return false;
+        // find tagged services and mark `method` as called
+        foreach (self::CALLABLE_TAGS as $tagName => $callerIdentifier) {
+            foreach (self::$containerMeta->findTaggedServices($tagName) as $id => $tags) {
+                foreach ($tags as $tag) {
+                    if (!is_array($tag) || !array_key_exists('method', $tag)) {
+                        continue;
+                    }
+                    $class = self::$containerMeta->get($id)->getClass();
+                    if (null === $class) {
+                        continue;
+                    }
+                    $method = $tag['method'] ?: '__invoke';
+                    $event->getCodebase()->methodExists($class.'::'.$method, null, $callerIdentifier);
+                }
+            }
         }
 
-        return null;
+        // get factories from container and mark container as caller
+        $callerIdentifier = new MethodIdentifier(Container::class, 'get');
+        foreach (self::$containerMeta->getInstanceClassFactories() as $factory) {
+            try {
+                $class = $factory[0] instanceof Reference ? self::$containerMeta->get((string) $factory[0])->getClass() : $factory[0];
+            } catch (ServiceNotFoundException) {
+                continue;
+            }
+            if (null === $class) {
+                continue;
+            }
+            $event->getCodebase()->methodExists($class.'::'.$factory[1], null, $callerIdentifier);
+        }
     }
 
     public static function isContainerMethod(string $declaringMethodId, string $methodName): bool
@@ -235,5 +369,73 @@ final class ContainerHandler implements AfterMethodCallAnalysisInterface, AfterC
     private static function followsNamingConvention(string $name): bool
     {
         return !preg_match('/[A-Z]/', $name);
+    }
+
+    private static function isDenormalizerMethod(string $methodName): bool
+    {
+        if (!str_starts_with($methodName, 'Symfony\Component\Serializer\\')) {
+            return false;
+        }
+
+        return str_ends_with($methodName, 'denormalize') || str_ends_with($methodName, 'deserialize');
+    }
+
+    /** @param array<string, true> $visited guard against circular references */
+    private static function markConstructorChainAsUsed(string $className, Codebase $codebase, string $callingMethodId, array &$visited): void
+    {
+        if (isset($visited[$className])) {
+            return;
+        }
+        $visited[$className] = true;
+
+        if ($codebase->classlike_storage_provider->has($className)) {
+            $classStorage = $codebase->classlike_storage_provider->get($className);
+            if (null !== $classStorage->location) {
+                $codebase->classExists($className, $classStorage->location, null, $callingMethodId);
+            }
+        }
+
+        $codebase->methodExists(new MethodIdentifier($className, '__construct'), null, $callingMethodId);
+
+        if (!$codebase->classlike_storage_provider->has($className)) {
+            return;
+        }
+
+        $classStorage = $codebase->classlike_storage_provider->get($className);
+
+        foreach ($classStorage->properties as $propertyStorage) {
+            $type = $propertyStorage->type ?? $propertyStorage->signature_type;
+            if (null === $type) {
+                continue;
+            }
+            foreach (self::extractNamedObjectClassNames($type) as $nestedClassName) {
+                self::markConstructorChainAsUsed($nestedClassName, $codebase, $callingMethodId, $visited);
+            }
+        }
+    }
+
+    /** @return string[] */
+    private static function extractNamedObjectClassNames(Union $type): array
+    {
+        $classNames = [];
+        foreach ($type->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNamedObject) {
+                $classNames[] = $atomic->value;
+            } elseif ($atomic instanceof TKeyedArray) {
+                // covers list<SubObject>, non-empty-list<SubObject>, and array{key: SubObject}
+                foreach ($atomic->properties as $propType) {
+                    foreach (self::extractNamedObjectClassNames($propType) as $name) {
+                        $classNames[] = $name;
+                    }
+                }
+            } elseif ($atomic instanceof TArray) {
+                // covers SubObject[] (array<array-key, SubObject>) and TNonEmptyArray
+                foreach (self::extractNamedObjectClassNames($atomic->type_params[1]) as $name) {
+                    $classNames[] = $name;
+                }
+            }
+        }
+
+        return $classNames;
     }
 }

--- a/src/Handler/RouterHandler.php
+++ b/src/Handler/RouterHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\SymfonyPsalmPlugin\Handler;
+
+use Psalm\Config;
+use Psalm\Internal\MethodIdentifier;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Fetches routes cache file and marks all methods, that are routes, as used.
+ */
+final class RouterHandler implements AfterCodebasePopulatedInterface
+{
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $callerIdentifier = new MethodIdentifier(Kernel::class, 'handle');
+        foreach (self::getRoutesFromCache() as $route) {
+            $controller = $route['_controller'] ?? '';
+            if (is_string($controller) && str_contains($controller, '\\')) {
+                [$class, $method] = self::parseController($controller);
+                $event->getCodebase()->methodExists($class.'::'.$method, null, $callerIdentifier);
+            }
+        }
+    }
+
+    private static function getRoutesFromCache(): array
+    {
+        $cacheFile = self::getRoutesCacheFilePath();
+
+        if (!is_file($cacheFile) || !is_readable($cacheFile)) {
+            return [];
+        }
+
+        return \array_column(include $cacheFile, 1);
+    }
+
+    private static function getRoutesCacheFilePath(): string
+    {
+        $baseDir = Config::getInstance()->base_dir;
+
+        return $baseDir.'/var/cache/dev/url_generating_routes.php';
+    }
+
+    /**
+     * @return list{class-string, string}
+     *
+     * @psalm-suppress InvalidReturnType, InvalidReturnStatement, LessSpecificReturnStatement
+     */
+    private static function parseController(string $controller): array
+    {
+        if (str_contains($controller, '::')) {
+            return explode('::', $controller);
+        }
+
+        return [$controller, '__invoke'];
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,6 +15,7 @@ use Psalm\SymfonyPsalmPlugin\Handler\DoctrineRepositoryHandler;
 use Psalm\SymfonyPsalmPlugin\Handler\HeaderBagHandler;
 use Psalm\SymfonyPsalmPlugin\Handler\ParameterBagHandler;
 use Psalm\SymfonyPsalmPlugin\Handler\RequiredSetterHandler;
+use Psalm\SymfonyPsalmPlugin\Handler\RouterHandler;
 use Psalm\SymfonyPsalmPlugin\Provider\FormGetErrorsReturnTypeProvider;
 use Psalm\SymfonyPsalmPlugin\Symfony\ContainerMeta;
 use Psalm\SymfonyPsalmPlugin\Twig\AnalyzedTemplatesTainter;
@@ -37,12 +38,14 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__.'/Handler/ConsoleHandler.php';
         require_once __DIR__.'/Handler/ContainerDependencyHandler.php';
         require_once __DIR__.'/Handler/RequiredSetterHandler.php';
+        require_once __DIR__.'/Handler/RouterHandler.php';
         require_once __DIR__.'/Provider/FormGetErrorsReturnTypeProvider.php';
 
         $registration->registerHooksFromClass(HeaderBagHandler::class);
         $registration->registerHooksFromClass(ConsoleHandler::class);
         $registration->registerHooksFromClass(ContainerDependencyHandler::class);
         $registration->registerHooksFromClass(RequiredSetterHandler::class);
+        $registration->registerHooksFromClass(RouterHandler::class);
 
         if (class_exists(\Doctrine\ORM\QueryBuilder::class)) {
             require_once __DIR__.'/Handler/DoctrineQueryBuilderHandler.php';

--- a/src/Symfony/ContainerMeta.php
+++ b/src/Symfony/ContainerMeta.php
@@ -103,6 +103,31 @@ final class ContainerMeta
         return $this->classNames;
     }
 
+    public function findTaggedServices(string $tagName): array
+    {
+        return $this->container->findTaggedServiceIds($tagName);
+    }
+
+    /** @return Definition[] */
+    public function getDefinitions(): array
+    {
+        return $this->container->getDefinitions();
+    }
+
+    /**
+     * @return \Iterator<int, list{string|Reference, string}>
+     *
+     * @psalm-suppress MoreSpecificReturnType
+     */
+    public function getInstanceClassFactories(): \Iterator
+    {
+        foreach ($this->container->getDefinitions() as $definition) {
+            if (is_array($factory = $definition->getFactory()) && null !== $factory[0] && 'Closure' !== $factory[0]) {
+                yield $factory;
+            }
+        }
+    }
+
     private function init(array $containerXmlPaths): void
     {
         $this->container = new ContainerBuilder();

--- a/src/Test/CodeceptionModule.php
+++ b/src/Test/CodeceptionModule.php
@@ -77,6 +77,22 @@ final class CodeceptionModule extends BaseModule
     }
 
     /**
+     * @Given I have the following file :filename :code
+     */
+    public function haveTheFollowingFile(string $filename, PyStringNode $code): void
+    {
+        $rootDirectory = rtrim($this->config['default_dir'], DIRECTORY_SEPARATOR);
+        $filePath = $rootDirectory.DIRECTORY_SEPARATOR.ltrim($filename, DIRECTORY_SEPARATOR);
+        $directory = dirname($filePath);
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        file_put_contents($filePath, $code->getRaw());
+    }
+
+    /**
      * @Given the :templateName template is compiled in the :cacheDirectory directory
      */
     public function haveTheTemplateCompiled(string $templateName, string $cacheDirectory): void

--- a/tests/acceptance/acceptance/AsController.feature
+++ b/tests/acceptance/acceptance/AsController.feature
@@ -1,0 +1,35 @@
+@symfony-common @php-8
+Feature: AsController dynamic callers
+  Mark invokable controllers as used
+
+  Scenario: AsController invokable class is marked as used
+    Given I have the following code in "container_as_controller.xml"
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+        <services>
+          <service id="App\Controller\InvokableController" class="App\Controller\InvokableController" public="true"/>
+        </services>
+      </container>
+      """
+    And I have Symfony plugin enabled with the following config
+      """
+      <containerXml>container_as_controller.xml</containerXml>
+      """
+    And I have the following code
+      """
+      <?php
+      namespace App\Controller;
+
+      use Symfony\Component\HttpKernel\Attribute\AsController;
+
+      #[AsController]
+      final class InvokableController
+      {
+        public function __invoke(): void
+        {
+        }
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors

--- a/tests/acceptance/acceptance/ContainerAlias.feature
+++ b/tests/acceptance/acceptance/ContainerAlias.feature
@@ -1,0 +1,57 @@
+@symfony-common @php-8
+Feature: Container service alias dead code detection
+
+  Scenario: Concrete class behind an interface alias is not reported as unused
+    Given I have the following code in "container_aliased_service.xml"
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+        <services>
+          <service id="App\Service\Foo" class="App\Service\Foo"/>
+          <service id="App\Contract\FooInterface" alias="App\Service\Foo"/>
+        </services>
+      </container>
+      """
+    And I have Symfony plugin enabled with the following config
+      """
+      <containerXml>container_aliased_service.xml</containerXml>
+      """
+    And I have the following code
+      """
+      <?php
+      namespace App\Contract;
+
+      interface FooInterface
+      {
+        public function run(): void;
+      }
+
+      namespace App\Service;
+
+      use App\Contract\FooInterface;
+
+      final class Foo implements FooInterface
+      {
+        public function __construct() {}
+
+        #[\Override]
+        public function run(): void {}
+
+        public function unused(): void {}
+      }
+
+      namespace App\Controller;
+      use Symfony\Component\HttpKernel\Attribute\AsController;
+
+      #[AsController]
+      final class Controller {
+        public function __invoke(\App\Contract\FooInterface $service): void {
+          $service->run();
+        }
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see these errors
+      | Issue | Message |
+      | PossiblyUnusedMethod | Cannot find any calls to method App\Service\Foo::unused |
+    And I see no other errors

--- a/tests/acceptance/acceptance/DenormalizerInterface.feature
+++ b/tests/acceptance/acceptance/DenormalizerInterface.feature
@@ -43,6 +43,123 @@ Feature: Denormalizer interface
       | Trace                  | $result: mixed                                                 |
     And I see no other errors
 
+  Scenario: Constructor of denormalized top-level class is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      final class Address {
+        public function __construct(public string $street) {}
+      }
+
+      function test(DenormalizerInterface $denormalizer): string
+      {
+        $address = $denormalizer->denormalize([], Address::class);
+        return $address->street;
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Constructor of typed sub-property is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Street {
+        public function __construct(public string $name) {}
+      }
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Address {
+        public function __construct(public Street $street) {}
+      }
+
+      function test(DenormalizerInterface $denormalizer): void
+      {
+        $denormalizer->denormalize([], Address::class);
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Constructor of array-collection sub-object is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Tag {
+        public function __construct(public string $name) {}
+      }
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Post {
+        /** @var Tag[] */
+        public array $tags = [];
+        public function __construct(public string $title) {}
+      }
+
+      function test(DenormalizerInterface $denormalizer): void
+      {
+        $denormalizer->denormalize([], Post::class);
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Constructor of list sub-object is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Tag {
+        public function __construct(public string $name) {}
+      }
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Post {
+        /** @var list<Tag> */
+        public array $tags = [];
+        public function __construct(public string $title) {}
+      }
+
+      function test(DenormalizerInterface $denormalizer): void
+      {
+        $denormalizer->denormalize([], Post::class);
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Circular object graph does not cause infinite recursion
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+      /** @psalm-suppress PossiblyUnusedProperty */
+      final class Node {
+        public ?Node $parent = null;
+        public function __construct(public string $value) {}
+      }
+
+      function test(DenormalizerInterface $denormalizer): void
+      {
+        $denormalizer->denormalize([], Node::class);
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
   Scenario: Psalm does not complain about the missing $data parameter type in the denormalizer implementation
     Given I have the following code
       """

--- a/tests/acceptance/acceptance/EventListener.feature
+++ b/tests/acceptance/acceptance/EventListener.feature
@@ -1,0 +1,40 @@
+@symfony-common @php-8
+Feature: Symfony EventListener
+
+  Scenario: kernel.event_listener tag method is marked as used
+    Given I have the following code in "container_event_listener.xml"
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+        <services>
+          <service id="App\Listener\ResponseListener" class="App\Listener\ResponseListener" public="true">
+            <tag name="kernel.event_listener" method="onResponse"/>
+          </service>
+        </services>
+      </container>
+      """
+    And I have Symfony plugin enabled with the following config
+      """
+      <containerXml>container_event_listener.xml</containerXml>
+      """
+    And I have the following code
+      """
+      <?php
+      namespace App\Listener;
+
+      use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+      final class ResponseListener
+      {
+        #[AsEventListener]
+        public function onResponse(): void {}
+
+        public function unusedMethod(): void {}
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see these errors
+      | Type | Message |
+      | PossiblyUnusedMethod | Cannot find any calls to method App\Listener\ResponseListener::unusedMethod |
+
+    And I see no other errors

--- a/tests/acceptance/acceptance/MapAttributes.feature
+++ b/tests/acceptance/acceptance/MapAttributes.feature
@@ -1,0 +1,127 @@
+@symfony-common @php-8
+Feature: MapQueryString and MapRequestPayload
+
+  Scenario: MapQueryString DTO constructor is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\HttpFoundation\Response;
+      use Symfony\Component\HttpKernel\Attribute\MapQueryString;
+      use Symfony\Component\Routing\Attribute\Route;
+
+      final class SearchQuery
+      {
+        public function __construct(public readonly string $q = '') {}
+      }
+
+      final class SearchController
+      {
+        #[Route('/search')]
+        public function search(#[MapQueryString] SearchQuery $query): Response
+        {
+          return new Response($query->q);
+        }
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: MapRequestPayload DTO constructor is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\HttpFoundation\Response;
+      use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+      use Symfony\Component\Routing\Attribute\Route;
+
+      final class CreateUserInput
+      {
+        public function __construct(public readonly string $name) {}
+      }
+
+      final class UserController
+      {
+        #[Route('/users', methods: ['POST'])]
+        public function create(#[MapRequestPayload] CreateUserInput $input): Response
+        {
+          return new Response($input->name);
+        }
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Nested DTO constructor is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\HttpFoundation\Response;
+      use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+      use Symfony\Component\Routing\Attribute\Route;
+
+      final class Address
+      {
+        public function __construct(public readonly string $city) {}
+      }
+
+      final class CreateUserInput
+      {
+        public function __construct(public readonly Address $address) {}
+      }
+
+      final class UserController
+      {
+        #[Route('/users', methods: ['POST'])]
+        public function create(#[MapRequestPayload] CreateUserInput $input): Response
+        {
+          return new Response($input->address->city);
+        }
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: Self-Referencing DTO does not cause infinite loop
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Symfony\Component\HttpFoundation\Response;
+      use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+      use Symfony\Component\Routing\Attribute\Route;
+
+      final class Node
+      {
+        public function __construct(
+          public string $name = '',
+          public ?Node $parent = null
+        ) {}
+
+        public function __toString(): string
+        {
+          return $this->name;
+        }
+
+        public function unused(): void {}
+      }
+
+      final class UserController
+      {
+        #[Route('/foo', methods: ['POST'])]
+        public function create(#[MapRequestPayload] Node $node): Response
+        {
+          return new Response((string) $node->parent);
+        }
+        public function unused(): void {}
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see these errors
+      | Issue | Message |
+      | PossiblyUnusedMethod | Cannot find any calls to method Node::unused           |
+      | PossiblyUnusedMethod | Cannot find any calls to method UserController::unused |
+
+    And I see no other errors

--- a/tests/acceptance/acceptance/Routes.feature
+++ b/tests/acceptance/acceptance/Routes.feature
@@ -1,0 +1,30 @@
+@symfony-common @php-8
+Feature: Router
+
+  Scenario: Controller action from default routes cache path is marked as used
+    Given I have Symfony plugin enabled
+    And I have the following file "var/cache/dev/url_generating_routes.php"
+      """
+      <?php
+      return [
+        'cached_route' => [
+          [],
+          ['_controller' => 'App\\Controller\\CachedController::fromCache'],
+        ],
+        'dummy_redirect' => [[], ['path' => 'http://example.com', 'permanent' => true, '_controller' => ['Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController', 'dummy_redirect']], [], [['text', '/redirect']], [], [], []],
+      ];
+      """
+    And I have the following code
+      """
+      <?php
+      namespace App\Controller;
+
+      final class CachedController
+      {
+        public function fromCache(): void
+        {
+        }
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors

--- a/tests/acceptance/acceptance/doctrine/EntityListener.feature
+++ b/tests/acceptance/acceptance/doctrine/EntityListener.feature
@@ -1,0 +1,36 @@
+@symfony-common @php-8
+Feature: Doctrine entity event listeners
+
+  Scenario: doctrine.orm.entity_listener tag method is marked as used
+    Given I have the following code in "container_entity_listener.xml"
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+        <services>
+          <service id="app.my_service_listener" class="App\EventListener\ProductListener">
+            <tag name="doctrine.orm.entity_listener" entity="App\Entity\Product" event="prePersist" method="onPrePersist"/>
+          </service>
+        </services>
+      </container>
+      """
+    And I have Symfony plugin enabled with the following config
+      """
+      <containerXml>container_entity_listener.xml</containerXml>
+      """
+    And I have the following code
+      """
+      <?php
+      namespace App\EventListener;
+
+      final class ProductListener
+      {
+        public function onPrePersist(): void {}
+
+        public function unusedMethod(): void {}
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see these errors
+      | Type                 | Message                                                                               |
+      | PossiblyUnusedMethod | Cannot find any calls to method App\EventListener\ProductListener::unusedMethod |
+    And I see no other errors

--- a/tests/acceptance/acceptance/doctrine/LifecycleCallbacks.feature
+++ b/tests/acceptance/acceptance/doctrine/LifecycleCallbacks.feature
@@ -1,0 +1,60 @@
+@symfony-common @php-8
+Feature: Doctrine lifecycle callbacks
+
+  Scenario: PrePersist method is not reported as unused
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Doctrine\ORM\Mapping as ORM;
+
+      final class Product
+      {
+        #[ORM\PrePersist]
+        public function onPrePersist(): void {}
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: All lifecycle callback attributes are recognized and flagged methods are still reported
+    Given I have Symfony plugin enabled
+    And I have the following code
+      """
+      <?php
+      use Doctrine\ORM\Mapping as ORM;
+
+      final class Order
+      {
+        #[ORM\PrePersist]
+        public function onPrePersist(): void {}
+
+        #[ORM\PostPersist]
+        public function onPostPersist(): void {}
+
+        #[ORM\PreUpdate]
+        public function onPreUpdate(): void {}
+
+        #[ORM\PostUpdate]
+        public function onPostUpdate(): void {}
+
+        #[ORM\PreRemove]
+        public function onPreRemove(): void {}
+
+        #[ORM\PostRemove]
+        public function onPostRemove(): void {}
+
+        #[ORM\PostLoad]
+        public function onPostLoad(): void {}
+
+        #[ORM\PreFlush]
+        public function onPreFlush(): void {}
+
+        public function unusedMethod(): void {}
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see these errors
+      | Type                | Message                                                          |
+      | PossiblyUnusedMethod | Cannot find any calls to method Order::unusedMethod |
+    And I see no other errors

--- a/tests/acceptance/acceptance/messenger/MessageHandler.feature
+++ b/tests/acceptance/acceptance/messenger/MessageHandler.feature
@@ -1,0 +1,75 @@
+@symfony-common @php-8
+Feature: Messenger message handler
+
+  Scenario: messenger.message_handler defaults to __invoke and is marked as used
+    Given I have the following code in "container_messenger.xml"
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+        <services>
+          <service id="custom.id" class="App\Message\DummyHandler">
+            <tag name="messenger.message_handler" method="" />
+          </service>
+        </services>
+      </container>
+      """
+    And I have Symfony plugin enabled with the following config
+      """
+      <containerXml>container_messenger.xml</containerXml>
+      """
+    And I have the following code
+      """
+      <?php
+      namespace App\Message;
+
+      use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+      #[AsMessageHandler]
+      final class DummyHandler
+      {
+        public function __invoke(): void
+        {
+        }
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see no errors
+
+  Scenario: messenger.message_handler method is marked as used
+    Given I have the following code in "container_messenger.xml"
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+        <services>
+          <service id="App\Message\DummyHandler" class="App\Message\DummyHandler">
+            <tag name="messenger.message_handler" method="onEvent" />
+          </service>
+        </services>
+      </container>
+      """
+    And I have Symfony plugin enabled with the following config
+      """
+      <containerXml>container_messenger.xml</containerXml>
+      """
+    And I have the following code
+      """
+      <?php
+      namespace App\Message;
+
+      use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+      final class DummyHandler
+      {
+        #[AsMessageHandler]
+        public function onEvent(): void
+        {
+        }
+
+        public function unused(): void {}
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see these errors
+      | Issue | Message |
+      | PossiblyUnusedMethod | Cannot find any calls to method App\Message\DummyHandler::unused |
+

--- a/tests/acceptance/acceptance/validator/Callback.feature
+++ b/tests/acceptance/acceptance/validator/Callback.feature
@@ -1,0 +1,40 @@
+@symfony-common @php-8
+Feature: Validator callback constraint
+
+  Scenario: Validator callback attribute method is marked as used
+    Given I have the following code in "container_validator.xml"
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+        <services>
+          <service id="validator" class="Symfony\Component\Validator\Validator\ValidatorInterface" public="true"/>
+        </services>
+      </container>
+      """
+    And I have Symfony plugin enabled with the following config
+      """
+      <containerXml>container_validator.xml</containerXml>
+      """
+    And I have the following code
+      """
+      <?php
+      namespace App\Validator;
+
+      use Symfony\Component\Validator\Constraints as Assert;
+
+      final class Payload
+      {
+        #[Assert\Callback]
+        public function calledByValidator(): void
+        {
+        }
+
+        public function unused(): void {}
+      }
+      """
+    When I run Psalm with dead code detection
+    Then I see these errors
+      | Issue | Message |
+      | PossiblyUnusedMethod | Cannot find any calls to method App\Validator\Payload::unused |
+    And I see no other errors
+


### PR DESCRIPTION
Currently, `UnusedClass` is suppressed for all services in the container. This is a symptom that Psalm does not statically see any usage where Symfony dynamically calls application code. So by adding call references, we can significantly improve dead code detection.

As the dumped debug container contains also unused services, they are effectively no longer detected.
Another issue is that when Psalm has no references to a class, member references are not even checked. So a class that is not statically called by application code might be completely unused or have unused methods / properties.
This is true for example for:
- EventListeners / Subscribers
- Messenger Message Handlers
- Controllers
- Service Aliases (Implementation is "unused" when Interface is the dependency)

I created a [dummy Symfony project](https://github.com/tunterreitmeier/symfony-psalm-dead-code) with examples of dead code that is currently not detected.
The repository has a GitHub Action that runs Psalm with this branch to showcase the difference.
I also ran this on larger code base where I was able to find quite a bit of genuinely unused code, remove suppression statements for false positives, without raising any new false positives.

## Changes
All services, constructors, factory methods and setter injections (e.g. `#[Required`) are now marked as used. 

Objects (and their nested sub-objects) created by Symfony Serializer via `Denormalizer::denormalize`, `Serializer::deserialize`, `#[MapRequestPayload]` or `#[MapQueryString]` are now marked as used.

Event Listener (also Doctrine ORM) and Subscriber methods are now marked as used.

Controller methods used as Routes are now marked as used.

