### PR TITLE
Improve twig cached template header pattern

### DIFF
--- a/src/Twig/CachedTemplatesMapping.php
+++ b/src/Twig/CachedTemplatesMapping.php
@@ -16,9 +16,9 @@ final class CachedTemplatesMapping implements AfterCodebasePopulatedInterface
      * @var string
      */
     public const CACHED_TEMPLATE_HEADER_PATTERN =
-        'use Twig\\\\Template;\n\n'.
+        'use Twig\\\\Template(?:Wrapper)?;\n\n'.
         '\/\* (?<name>@?.+\.twig) \*\/\n'.
-        'class (?<class>__TwigTemplate_[a-z0-9]{64}) extends (\\\\Twig\\\\)?Template';
+        'class (?<class>__TwigTemplate_(?:[a-z0-9]{32}|[a-z0-9]{64})) extends (\\\\Twig\\\\)?Template';
 
     private static ?string $cachePath = null;
 


### PR DESCRIPTION
Since PHP8, twig template classname use xxh128 hash algo instead of sha256 that create 32 characters length hash. (@see https://github.com/twigphp/Twig/blob/3.x/src/Environment.php#L319)

And it could be generated with `use Twig\TemplateWrapper` and not `Twig\Template` for last use
(@see https://github.com/twigphp/Twig/blame/3.x/src/Node/ModuleNode.php#L183)