### PR TITLE
Make expression language dependency optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": ">=8.1",
         "ext-simplexml": "*",
-        "symfony/expression-language": "^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/framework-bundle": "^5.0 || ^6.0 || ^7.0 || ^8.0",
         "vimeo/psalm": "^6 || dev-master"
     },
@@ -22,6 +21,7 @@
         "phpunit/phpunit": "~7.5 || ~9.5",
         "symfony/cache-contracts": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "*",
+        "symfony/expression-language": "^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/form": "^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/messenger": "^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/security-core": "*",


### PR DESCRIPTION
The expression language is only used in the `XmlFileLoader` but if your project doesn't use it the loader will not encounter any property that requires it so it should be safe to make it optional.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-symfony/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786288559&installation_id=141955579&pr_number=386&repository=psalm%2Fpsalm-plugin-symfony&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-symfony%2Fpull%2F386&signature=0d68519ddc4220a25de6621572e71165ec97940a6349e135768834a7d8d76f7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->